### PR TITLE
feat: bug and feature reporting system

### DIFF
--- a/app/api/bug-report/route.ts
+++ b/app/api/bug-report/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase-server';
+import { createClient as createSupabaseClient } from '@supabase/supabase-js';
+
+// TODO: Set GITHUB_TOKEN as an environment variable in Vercel dashboard before deploying.
+// GITHUB_TOKEN is loaded from ~/.openclaw/.env on this machine.
+
+/**
+ * POST /api/bug-report
+ *
+ * Creates a GitHub issue and logs the report to Supabase.
+ * Works for both authenticated and unauthenticated users.
+ *
+ * Body: { title: string, description?: string, steps?: string, type: "bug" | "feature" }
+ */
+export async function POST(req: NextRequest) {
+  const body = await req.json() as {
+    title?: string;
+    description?: string;
+    steps?: string;
+    type?: string;
+  };
+
+  const { title, description, steps, type } = body;
+
+  if (!title || typeof title !== 'string' || !title.trim()) {
+    return NextResponse.json({ error: 'title is required' }, { status: 400 });
+  }
+
+  const reportType: 'bug' | 'feature' = type === 'feature' ? 'feature' : 'bug';
+
+  // Get current user — optional, no auth required
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  const isKirby = !!user?.id && user.id === process.env.KIRBY_USER_ID;
+
+  // Build labels
+  const labels: string[] = reportType === 'bug' ? ['bug'] : ['enhancement'];
+  labels.push(isKirby ? 'internal' : 'user-reported');
+
+  // Build issue body
+  const bodyParts: string[] = [];
+  if (description?.trim()) {
+    bodyParts.push(description.trim());
+  }
+  if (reportType === 'bug' && steps?.trim()) {
+    bodyParts.push(`## Steps to reproduce\n\n${steps.trim()}`);
+  }
+  bodyParts.push('---\n_Reported via Anchor app_');
+  const issueBody = bodyParts.join('\n\n');
+
+  // POST to GitHub
+  const githubRes = await fetch('https://api.github.com/repos/kjswalls/v0-anchor/issues', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'anchor-app',
+    },
+    body: JSON.stringify({ title: title.trim(), body: issueBody, labels }),
+  });
+
+  if (githubRes.status !== 201) {
+    console.error('GitHub issue creation failed:', githubRes.status, await githubRes.text());
+    return NextResponse.json({ error: 'Failed to create issue' }, { status: 500 });
+  }
+
+  const issueData = await githubRes.json() as { number: number; html_url: string };
+
+  // Insert into bug_reports using service role client
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!serviceRoleKey) {
+    console.warn('SUPABASE_SERVICE_ROLE_KEY not set — skipping bug_reports insert');
+  } else {
+    const serviceClient = createSupabaseClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      serviceRoleKey
+    );
+    const { error: insertError } = await serviceClient.from('bug_reports').insert({
+      github_issue_number: issueData.number,
+      supabase_user_id: user?.id ?? null,
+      user_email: user?.email ?? null,
+      report_type: reportType,
+    });
+    if (insertError) {
+      console.error('bug_reports insert failed:', insertError.message);
+    }
+  }
+
+  return NextResponse.json({
+    ok: true,
+    issueNumber: issueData.number,
+    issueUrl: issueData.html_url,
+  });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,6 +21,7 @@ import { MobileTasksPanel } from '@/components/mobile/mobile-tasks-panel';
 import { MobileSchedulePanel } from '@/components/mobile/mobile-schedule-panel';
 import { MobileChatPanel } from '@/components/mobile/mobile-chat-panel';
 import { OnboardingTour } from '@/components/onboarding/onboarding-tour';
+import { BugReportDialog } from '@/components/bug-report/bug-report-dialog';
 import { useMobileNavStore } from '@/lib/mobile-nav-store';
 import { usePlannerStore } from '@/lib/planner-store';
 import { useSidebarStore } from '@/lib/sidebar-store';
@@ -114,6 +115,7 @@ export default function PlannerPage() {
   const [showTour, setShowTour] = useState(false);
   const [tourUserId, setTourUserId] = useState<string | null>(null);
   const [searchOpen, setSearchOpen] = useState(false);
+  const [bugReportOpen, setBugReportOpen] = useState(false);
   // Keyboard shortcut delete confirmation
   const [shortcutDeleteTarget, setShortcutDeleteTarget] = useState<{ id: string; type: 'task' | 'habit'; title: string } | null>(null);
   
@@ -379,6 +381,7 @@ const handleAddFromTopNav = () => {
     new_task: handleShortcutNewTask,
     edit_hovered: handleShortcutEdit,
     delete_hovered: handleShortcutDelete,
+    report_bug: useCallback(() => setBugReportOpen(true), []),
   });
 
   // Render skeleton during SSR to avoid hydration mismatch from dnd-kit
@@ -572,6 +575,7 @@ const handleAddFromTopNav = () => {
         open={settingsOpen}
         onOpenChange={setSettingsOpen}
         onOpenKeyboardShortcuts={() => setKeyboardShortcutsOpen(true)}
+        onReportBug={() => setBugReportOpen(true)}
         onReplayTour={async () => {
           const supabase = createClient();
           const { data } = await supabase.auth.getUser();
@@ -600,6 +604,8 @@ const handleAddFromTopNav = () => {
       )}
 
       <EODReview />
+
+      <BugReportDialog open={bugReportOpen} onOpenChange={setBugReportOpen} />
 
       {/* Persistent keyboard shortcuts hint — desktop only */}
       <div className="hidden md:flex fixed bottom-4 right-4 z-30">

--- a/components/bug-report/bug-report-dialog.tsx
+++ b/components/bug-report/bug-report-dialog.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { useState } from 'react';
+import { MessageSquarePlus } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+import { toast } from 'sonner';
+
+type ReportType = 'bug' | 'feature';
+
+interface BugReportDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function BugReportDialog({ open, onOpenChange }: BugReportDialogProps) {
+  const [type, setType] = useState<ReportType>('bug');
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [steps, setSteps] = useState('');
+  const [showSteps, setShowSteps] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setTitle('');
+      setDescription('');
+      setSteps('');
+      setShowSteps(false);
+      setType('bug');
+    }
+    onOpenChange(nextOpen);
+  };
+
+  const handleSubmit = async () => {
+    if (!title.trim()) return;
+    setLoading(true);
+    try {
+      const res = await fetch('/api/bug-report', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: title.trim(),
+          description: description.trim() || undefined,
+          steps: type === 'bug' && steps.trim() ? steps.trim() : undefined,
+          type,
+        }),
+      });
+      if (res.ok) {
+        if (type === 'bug') {
+          toast.success("Bug reported! We'll look into it 🐉");
+        } else {
+          toast.success('Feature request sent! Love the idea 🐉');
+        }
+        handleOpenChange(false);
+      } else {
+        toast.error('Failed to send. Try again?');
+      }
+    } catch {
+      toast.error('Failed to send. Try again?');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md bg-card border-border">
+        <DialogHeader>
+          <DialogTitle className="text-foreground flex items-center gap-2">
+            <MessageSquarePlus className="h-5 w-5" />
+            Share feedback 🐛
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            Report a bug or request a feature.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Type toggle */}
+          <div className="flex gap-1 p-1 rounded-lg bg-muted w-fit">
+            <button
+              onClick={() => setType('bug')}
+              className={cn(
+                'px-3 py-1.5 rounded-md text-sm font-medium transition-colors',
+                type === 'bug'
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+            >
+              Bug report
+            </button>
+            <button
+              onClick={() => setType('feature')}
+              className={cn(
+                'px-3 py-1.5 rounded-md text-sm font-medium transition-colors',
+                type === 'feature'
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+            >
+              Feature request
+            </button>
+          </div>
+
+          {/* Title */}
+          <div className="space-y-1.5">
+            <Label htmlFor="report-title" className="text-sm">
+              Title <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="report-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder={type === 'bug' ? 'What went wrong?' : 'What would you like to see?'}
+              className="text-sm"
+            />
+          </div>
+
+          {/* Description */}
+          <div className="space-y-1.5">
+            <Label htmlFor="report-description" className="text-sm">
+              Description
+            </Label>
+            <Textarea
+              id="report-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder={
+                type === 'bug'
+                  ? 'Describe the bug and what you expected to happen...'
+                  : 'Describe the feature and why it would be useful...'
+              }
+              className="text-sm min-h-[80px] resize-none"
+            />
+          </div>
+
+          {/* Steps to reproduce — bug only */}
+          {type === 'bug' && (
+            <div className="space-y-1.5">
+              {!showSteps ? (
+                <button
+                  onClick={() => setShowSteps(true)}
+                  className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2 transition-colors"
+                >
+                  + Add steps to reproduce
+                </button>
+              ) : (
+                <>
+                  <Label htmlFor="report-steps" className="text-sm">
+                    Steps to reproduce
+                  </Label>
+                  <Textarea
+                    id="report-steps"
+                    value={steps}
+                    onChange={(e) => setSteps(e.target.value)}
+                    placeholder="1. Go to...&#10;2. Click on...&#10;3. See error"
+                    className="text-sm min-h-[80px] resize-none"
+                  />
+                </>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="outline" size="sm" onClick={() => handleOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleSubmit}
+            disabled={!title.trim() || loading}
+          >
+            {loading ? 'Sending…' : type === 'bug' ? 'Send bug report' : 'Send feature request'}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/planner/settings-dialog.tsx
+++ b/components/planner/settings-dialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Settings, ChevronDown, Globe, Calendar, Bell, Palette, Sun, Keyboard, Sparkles, ExternalLink, RotateCw } from 'lucide-react';
+import { Settings, ChevronDown, Globe, Calendar, Bell, Palette, Sun, Keyboard, Sparkles, ExternalLink, RotateCw, MessageSquarePlus } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -38,6 +38,7 @@ interface SettingsDialogProps {
   onOpenChange: (open: boolean) => void;
   onOpenKeyboardShortcuts?: () => void;
   onReplayTour?: () => void;
+  onReportBug?: () => void;
 }
 
 interface SettingsSectionProps {
@@ -95,7 +96,7 @@ function SettingRow({ label, description, children, disabled }: { label: string;
 }
 
 
-export function SettingsDialog({ open, onOpenChange, onOpenKeyboardShortcuts, onReplayTour }: SettingsDialogProps) {
+export function SettingsDialog({ open, onOpenChange, onOpenKeyboardShortcuts, onReplayTour, onReportBug }: SettingsDialogProps) {
   // These would be connected to a settings store in a full implementation
   const [language, setLanguage] = useState('en');
   const [timeFormat, setTimeFormat] = useState('12h');
@@ -428,16 +429,27 @@ export function SettingsDialog({ open, onOpenChange, onOpenKeyboardShortcuts, on
         </div>
 
         <div className="flex items-center justify-between pt-4 border-t border-border">
-          <button
-            className="text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1.5"
-            onClick={() => {
-              onOpenChange(false);
-              onReplayTour?.();
-            }}
-          >
-            <RotateCw className="h-3 w-3" />
-            Replay onboarding tour
-          </button>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="gap-1.5 text-muted-foreground"
+              onClick={onReportBug}
+            >
+              <MessageSquarePlus className="h-3.5 w-3.5" />
+              Share feedback
+            </Button>
+            <button
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1.5"
+              onClick={() => {
+                onOpenChange(false);
+                onReplayTour?.();
+              }}
+            >
+              <RotateCw className="h-3 w-3" />
+              Replay onboarding tour
+            </button>
+          </div>
           <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
             Done
           </Button>

--- a/lib/keyboard-shortcuts-store.ts
+++ b/lib/keyboard-shortcuts-store.ts
@@ -73,6 +73,12 @@ export const DEFAULT_SHORTCUTS: ShortcutBinding[] = [
     description: 'Focus the search bar',
     keys: ['meta', 'k'],
   },
+  {
+    id: 'report_bug',
+    label: 'Report a bug',
+    description: 'Open the bug / feature report dialog',
+    keys: ['?'],
+  },
 ];
 
 // Keep for backward compatibility — no longer used for rendering

--- a/supabase/migrations/006_bug_reports.sql
+++ b/supabase/migrations/006_bug_reports.sql
@@ -1,0 +1,11 @@
+create table if not exists public.bug_reports (
+  id uuid primary key default gen_random_uuid(),
+  github_issue_number integer unique,
+  supabase_user_id uuid references auth.users(id) on delete set null,
+  user_email text,
+  report_type text not null default 'bug',
+  created_at timestamptz default now(),
+  resolved_at timestamptz
+);
+
+alter table public.bug_reports enable row level security;


### PR DESCRIPTION
## Summary

- Adds `?` keyboard shortcut to open the Share Feedback dialog (bug reports & feature requests)
- New `BugReportDialog` component with bug/feature toggle, title, description, optional steps-to-reproduce field, loading state, and toast feedback
- Settings dialog footer gets a **Share Feedback** button wired to the same dialog
- `POST /api/bug-report` creates a GitHub Issue with labels (`bug`/`enhancement` + `internal`/`user-reported`), then logs the report to Supabase via service role client
- `supabase/migrations/006_bug_reports.sql` — creates `bug_reports` table (not auto-run)
- `.env.local` gets placeholder comments for `KIRBY_USER_ID` and `SUPABASE_SERVICE_ROLE_KEY`

## Test plan

- [ ] Press `?` on the planner page (not in an input) — dialog opens
- [ ] Toggle between Bug report / Feature request tabs — placeholder text and submit label change
- [ ] Submit with empty title — button stays disabled
- [ ] Submit a bug report — GitHub issue created with `bug` + `internal`/`user-reported` label, success toast shown
- [ ] Submit a feature request — issue created with `enhancement` label, toast says "Love the idea 🐉"
- [ ] Open Settings → click **Share Feedback** in footer — same dialog opens
- [ ] "Add steps to reproduce" toggle reveals the steps textarea (bug mode only)
- [ ] Dialog resets all fields on close

🤖 Generated with [Claude Code](https://claude.com/claude-code)