### PR TITLE
feat: wire up settings + Supabase persistence

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -235,3 +235,13 @@
   min-height: 44px;
   min-width: 44px;
 }
+
+/* Reduce motion when animations are disabled */
+[data-reduce-motion="true"] *,
+[data-reduce-motion="true"] *::before,
+[data-reduce-motion="true"] *::after {
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.01ms !important;
+  scroll-behavior: auto !important;
+}

--- a/components/ai/chat-sidebar.tsx
+++ b/components/ai/chat-sidebar.tsx
@@ -14,6 +14,7 @@ import { useAISettingsStore, PERSONALITY_PROMPTS } from '@/lib/ai-settings-store
 import { useSidebarStore } from '@/lib/sidebar-store'
 import { cn } from '@/lib/utils'
 import { format } from 'date-fns'
+import { useTimeFormat } from '@/lib/use-time-format'
 import ReactMarkdown from 'react-markdown'
 
 interface Message {
@@ -34,6 +35,7 @@ const DEFAULT_WIDTH = 380
 export function ChatSidebar() {
   const { rightSidebarOpen: isOpen, rightSidebarHovered, rightSidebarHoverEnabled, setRightSidebarOpen: setIsOpen, toggleRightSidebar, setRightSidebarHovered } = useSidebarStore()
   const isVisible = isOpen || (rightSidebarHoverEnabled && rightSidebarHovered)
+  const timeFormatStr = useTimeFormat()
   const [mounted, setMounted] = useState(false)
   const [messages, setMessages] = useState<Message[]>([])
   const [input, setInput] = useState('')
@@ -368,7 +370,7 @@ export function ChatSidebar() {
                                 <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
                                   {msg.timestamp && (
                                     <span className="text-[10px] text-muted-foreground">
-                                      {format(msg.timestamp, 'h:mm a')}
+                                      {format(msg.timestamp, timeFormatStr)}
                                     </span>
                                   )}
                                   <button
@@ -398,7 +400,7 @@ export function ChatSidebar() {
                               <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
                                 {msg.timestamp && (
                                   <span className="text-[10px] text-muted-foreground">
-                                    {format(msg.timestamp, 'h:mm a')}
+                                    {format(msg.timestamp, timeFormatStr)}
                                   </span>
                                 )}
                                 {msg.content && (

--- a/components/mobile/mini-week-nav.tsx
+++ b/components/mobile/mini-week-nav.tsx
@@ -8,11 +8,12 @@ import { usePlannerStore } from '@/lib/planner-store';
 import { cn } from '@/lib/utils';
 
 export function MiniWeekNav() {
-  const { selectedDate, setSelectedDate, setNavDirection } = usePlannerStore();
+  const { selectedDate, setSelectedDate, setNavDirection, weekStartDay } = usePlannerStore();
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  
+
   // Get days for 3 weeks: previous, current, next
-  const weekStart = startOfWeek(selectedDate, { weekStartsOn: 0 });
+  const weekStartsOn = weekStartDay === 'monday' ? 1 : weekStartDay === 'saturday' ? 6 : 0;
+  const weekStart = startOfWeek(selectedDate, { weekStartsOn: weekStartsOn as 0 | 1 | 6 });
   const days = Array.from({ length: 21 }, (_, i) => addDays(subDays(weekStart, 7), i));
 
   const goPrevious = () => {

--- a/components/mobile/mobile-chat-panel.tsx
+++ b/components/mobile/mobile-chat-panel.tsx
@@ -14,6 +14,7 @@ import { useMobileNavStore } from '@/lib/mobile-nav-store';
 import { cn } from '@/lib/utils';
 import { format } from 'date-fns';
 import ReactMarkdown from 'react-markdown';
+import { useTimeFormat } from '@/lib/use-time-format';
 
 interface Message {
   role: 'user' | 'assistant';
@@ -39,6 +40,7 @@ export function MobileChatPanel() {
   const aiProvider = useAISettingsStore((s) => s.provider);
   const activeTab = useMobileNavStore((s) => s.activeTab);
   const displayName = aiProvider === 'openclaw' ? OPENCLAW_NAME : ASSISTANT_NAME;
+  const timeFormatStr = useTimeFormat();
 
   // Check auth + onboarding status
   useEffect(() => {
@@ -274,7 +276,7 @@ export function MobileChatPanel() {
                           )}>
                             {msg.timestamp && (
                               <span className="text-[10px] text-muted-foreground">
-                                {format(msg.timestamp, 'h:mm a')}
+                                {format(msg.timestamp, timeFormatStr)}
                               </span>
                             )}
                             <button
@@ -307,7 +309,7 @@ export function MobileChatPanel() {
                         )}>
                           {msg.timestamp && (
                             <span className="text-[10px] text-muted-foreground">
-                              {format(msg.timestamp, 'h:mm a')}
+                              {format(msg.timestamp, timeFormatStr)}
                             </span>
                           )}
                           {msg.content && (

--- a/components/planner/add-task-dialog.tsx
+++ b/components/planner/add-task-dialog.tsx
@@ -51,10 +51,10 @@ interface AddTaskDialogProps {
 }
 
 export function AddTaskDialog({ open, onOpenChange, defaultTab = 'task', defaultBucket, defaultDate }: AddTaskDialogProps) {
-  const { 
-    addTask, addHabit, projects, habitGroups, scheduleTask, 
+  const {
+    addTask, addHabit, projects, habitGroups, scheduleTask,
     addProject, removeProject, addHabitGroup, removeHabitGroup,
-    selectedDate
+    selectedDate, defaultTimeBucket
   } = usePlannerStore();
   const [activeTab, setActiveTab] = useState<'task' | 'habit'>(defaultTab);
   
@@ -64,7 +64,7 @@ export function AddTaskDialog({ open, onOpenChange, defaultTab = 'task', default
   const [taskProject, setTaskProject] = useState<string>('');
   const [taskStartDate, setTaskStartDate] = useState<Date | undefined>(undefined);
   const [taskDuration, setTaskDuration] = useState<string>('30');
-  const [taskTimeBucket, setTaskTimeBucket] = useState<TimeBucket | undefined>(defaultBucket);
+  const [taskTimeBucket, setTaskTimeBucket] = useState<TimeBucket | undefined>(defaultBucket ?? defaultTimeBucket);
   const [taskStartTime, setTaskStartTime] = useState<string>('');
   const [taskRepeatFrequency, setTaskRepeatFrequency] = useState<RepeatFrequency>('none');
   const [taskRepeatDays, setTaskRepeatDays] = useState<number[]>([]);
@@ -73,7 +73,7 @@ export function AddTaskDialog({ open, onOpenChange, defaultTab = 'task', default
   // Habit state
   const [habitTitle, setHabitTitle] = useState('');
   const [habitGroup, setHabitGroup] = useState<string>(habitGroups[0]?.name || 'personal');
-  const [habitTimeBucket, setHabitTimeBucket] = useState<TimeBucket>(defaultBucket || 'anytime');
+  const [habitTimeBucket, setHabitTimeBucket] = useState<TimeBucket>(defaultBucket ?? defaultTimeBucket ?? 'anytime');
   const [habitStartTime, setHabitStartTime] = useState<string>('');
   const [habitRepeatFrequency, setHabitRepeatFrequency] = useState<RepeatFrequency>('daily');
   const [habitRepeatDays, setHabitRepeatDays] = useState<number[]>([]);
@@ -95,12 +95,12 @@ export function AddTaskDialog({ open, onOpenChange, defaultTab = 'task', default
   useEffect(() => {
     if (open) {
       setActiveTab(defaultTab);
-      setTaskTimeBucket(defaultBucket);
-      setHabitTimeBucket(defaultBucket || 'anytime');
+      setTaskTimeBucket(defaultBucket ?? defaultTimeBucket);
+      setHabitTimeBucket(defaultBucket ?? defaultTimeBucket ?? 'anytime');
       // Set date if defaultDate is provided (e.g., when adding from a bucket)
       setTaskStartDate(defaultDate);
     }
-  }, [open, defaultTab, defaultBucket, defaultDate]);
+  }, [open, defaultTab, defaultBucket, defaultDate, defaultTimeBucket]);
 
   const resetForm = () => {
     setTaskTitle('');
@@ -108,14 +108,14 @@ export function AddTaskDialog({ open, onOpenChange, defaultTab = 'task', default
     setTaskProject('');
     setTaskStartDate(undefined);
     setTaskDuration('30');
-    setTaskTimeBucket(defaultBucket);
+    setTaskTimeBucket(defaultBucket ?? defaultTimeBucket);
     setTaskStartTime('');
     setTaskRepeatFrequency('none');
     setTaskRepeatDays([]);
     setTaskRepeatMonthDay(1);
     setHabitTitle('');
     setHabitGroup(habitGroups[0]?.name || 'personal');
-    setHabitTimeBucket(defaultBucket || 'anytime');
+    setHabitTimeBucket(defaultBucket ?? defaultTimeBucket ?? 'anytime');
     setHabitStartTime('');
     setHabitRepeatFrequency('daily');
     setHabitRepeatDays([]);

--- a/components/planner/settings-dialog.tsx
+++ b/components/planner/settings-dialog.tsx
@@ -32,6 +32,9 @@ import { useMorningStore } from '@/lib/morning-store';
 import { useEODStore } from '@/lib/eod-store';
 import { useAISettingsStore, AIProvider } from '@/lib/ai-settings-store';
 import { useSidebarStore } from '@/lib/sidebar-store';
+import { saveSettings } from '@/lib/settings-service';
+import { useTheme } from 'next-themes';
+import { useIsMobile } from '@/components/ui/use-mobile';
 
 interface SettingsDialogProps {
   open: boolean;
@@ -74,7 +77,7 @@ function SettingsSection({ title, icon, children, defaultOpen = false }: Setting
   );
 }
 
-function SettingRow({ label, description, children, disabled }: { label: string; description?: string; children: React.ReactNode; disabled?: boolean }) {
+function SettingRow({ label, description, children, disabled, badge }: { label: string; description?: string; children: React.ReactNode; disabled?: boolean; badge?: string }) {
   return (
     <div className={cn("flex items-center justify-between gap-4", disabled && "opacity-50 pointer-events-none")}>
       <div className="space-y-0.5">
@@ -82,7 +85,7 @@ function SettingRow({ label, description, children, disabled }: { label: string;
           <Label className="text-sm text-foreground">{label}</Label>
           {disabled && (
             <Badge variant="outline" className="text-[10px] px-1.5 py-0 h-4 font-normal text-muted-foreground border-muted-foreground/30">
-              Coming soon
+              {badge ?? 'Coming soon'}
             </Badge>
           )}
         </div>
@@ -99,17 +102,13 @@ function SettingRow({ label, description, children, disabled }: { label: string;
 export function SettingsDialog({ open, onOpenChange, onOpenKeyboardShortcuts, onReplayTour, onReportBug }: SettingsDialogProps) {
   // These would be connected to a settings store in a full implementation
   const [language, setLanguage] = useState('en');
-  const [timeFormat, setTimeFormat] = useState('12h');
   const [notificationsEnabled, setNotificationsEnabled] = useState(true);
   const [habitReminders, setHabitReminders] = useState(true);
   const [taskReminders, setTaskReminders] = useState(true);
   const [soundEnabled, setSoundEnabled] = useState(false);
-  const [compactMode, setCompactModeLocal] = useState(false);
-  const [showCompleted, setShowCompleted] = useState(true);
-  const [animationsEnabled, setAnimationsEnabled] = useState(true);
-  const [weekStartDay, setWeekStartDay] = useState('sunday');
-  const [theme, setTheme] = useState('system');
-  const { compactMode: storeCompactMode, setCompactMode, chillMode, setChillMode, showCurrentTimeIndicator, setShowCurrentTimeIndicator } = usePlannerStore();
+  const { compactMode: storeCompactMode, setCompactMode, chillMode, setChillMode, showCurrentTimeIndicator, setShowCurrentTimeIndicator, userId, showCompletedTasks, setShowCompletedTasks, animationsEnabled, setAnimationsEnabled, weekStartDay, setWeekStartDay, defaultView, setDefaultView, defaultTimeBucket, setDefaultTimeBucket, timeFormat, setTimeFormat } = usePlannerStore();
+  const { theme, setTheme } = useTheme();
+  const isMobile = useIsMobile();
   const { morningCheckEnabled, setMorningCheckEnabled } = useMorningStore();
   useEODStore();
 
@@ -149,7 +148,7 @@ export function SettingsDialog({ open, onOpenChange, onOpenKeyboardShortcuts, on
               icon={<Globe className="h-4 w-4" />}
               defaultOpen={true}
             >
-              <SettingRow label="Language" description="Choose your preferred language" disabled>
+              <SettingRow label="Language" description="Choose your preferred language" disabled badge="Phase 2">
                 <Select value={language} onValueChange={setLanguage}>
                   <SelectTrigger className="w-32 h-8 text-xs">
                     <SelectValue />
@@ -165,8 +164,8 @@ export function SettingsDialog({ open, onOpenChange, onOpenKeyboardShortcuts, on
                 </Select>
               </SettingRow>
 
-              <SettingRow label="Time format" description="How times are displayed" disabled>
-                <Select value={timeFormat} onValueChange={setTimeFormat}>
+              <SettingRow label="Time format" description="How times are displayed">
+                <Select value={timeFormat} onValueChange={(v) => setTimeFormat(v as '12h' | '24h')}>
                   <SelectTrigger className="w-32 h-8 text-xs">
                     <SelectValue />
                   </SelectTrigger>
@@ -183,32 +182,32 @@ export function SettingsDialog({ open, onOpenChange, onOpenKeyboardShortcuts, on
               title="Notifications" 
               icon={<Bell className="h-4 w-4" />}
             >
-              <SettingRow label="Enable notifications" description="Receive reminders and alerts" disabled>
-                <Switch 
-                  checked={notificationsEnabled} 
+              <SettingRow label="Enable notifications" description="Receive reminders and alerts" disabled badge="Requires push notifications">
+                <Switch
+                  checked={notificationsEnabled}
                   onCheckedChange={setNotificationsEnabled}
                 />
               </SettingRow>
 
-              <SettingRow label="Habit reminders" description="Get reminded about daily habits" disabled>
-                <Switch 
-                  checked={habitReminders} 
+              <SettingRow label="Habit reminders" description="Get reminded about daily habits" disabled badge="Requires push notifications">
+                <Switch
+                  checked={habitReminders}
                   onCheckedChange={setHabitReminders}
                   disabled={!notificationsEnabled}
                 />
               </SettingRow>
 
-              <SettingRow label="Task reminders" description="Get reminded about upcoming tasks" disabled>
-                <Switch 
-                  checked={taskReminders} 
+              <SettingRow label="Task reminders" description="Get reminded about upcoming tasks" disabled badge="Requires push notifications">
+                <Switch
+                  checked={taskReminders}
                   onCheckedChange={setTaskReminders}
                   disabled={!notificationsEnabled}
                 />
               </SettingRow>
 
-              <SettingRow label="Sound effects" description="Play sounds for notifications" disabled>
-                <Switch 
-                  checked={soundEnabled} 
+              <SettingRow label="Sound effects" description="Play sounds for notifications" disabled badge="Requires push notifications">
+                <Switch
+                  checked={soundEnabled}
                   onCheckedChange={setSoundEnabled}
                   disabled={!notificationsEnabled}
                 />
@@ -220,8 +219,11 @@ export function SettingsDialog({ open, onOpenChange, onOpenKeyboardShortcuts, on
               title="Appearance" 
               icon={<Palette className="h-4 w-4" />}
             >
-              <SettingRow label="Theme" description="Choose your preferred theme" disabled>
-                <Select value={theme} onValueChange={setTheme}>
+              <SettingRow label="Theme" description="Choose your preferred theme">
+                <Select value={theme ?? 'system'} onValueChange={(v) => {
+                  setTheme(v);
+                  if (userId) saveSettings(userId, { theme: v });
+                }}>
                   <SelectTrigger className="w-32 h-8 text-xs">
                     <SelectValue />
                   </SelectTrigger>
@@ -247,16 +249,16 @@ export function SettingsDialog({ open, onOpenChange, onOpenKeyboardShortcuts, on
                 />
               </SettingRow>
 
-              <SettingRow label="Show completed tasks" description="Display completed tasks in timeline" disabled>
-                <Switch 
-                  checked={showCompleted} 
-                  onCheckedChange={setShowCompleted}
+              <SettingRow label="Show completed tasks" description="Display completed tasks in timeline">
+                <Switch
+                  checked={showCompletedTasks}
+                  onCheckedChange={setShowCompletedTasks}
                 />
               </SettingRow>
 
-              <SettingRow label="Animations" description="Enable smooth transitions" disabled>
-                <Switch 
-                  checked={animationsEnabled} 
+              <SettingRow label="Animations" description="Enable smooth transitions">
+                <Switch
+                  checked={animationsEnabled}
                   onCheckedChange={setAnimationsEnabled}
                 />
               </SettingRow>
@@ -284,19 +286,21 @@ export function SettingsDialog({ open, onOpenChange, onOpenKeyboardShortcuts, on
             </SettingsSection>
 
             {/* Keyboard Shortcuts */}
-            <button
-              className="flex items-center justify-between w-full px-4 py-3 hover:bg-accent/50 rounded-lg transition-colors"
-              onClick={() => {
-                onOpenChange(false);
-                onOpenKeyboardShortcuts?.();
-              }}
-            >
-              <div className="flex items-center gap-3">
-                <div className="text-muted-foreground"><Keyboard className="h-4 w-4" /></div>
-                <span className="text-sm font-medium text-foreground">Keyboard Shortcuts</span>
-              </div>
-              <ExternalLink className="h-3.5 w-3.5 text-muted-foreground" />
-            </button>
+            {!isMobile && (
+              <button
+                className="flex items-center justify-between w-full px-4 py-3 hover:bg-accent/50 rounded-lg transition-colors"
+                onClick={() => {
+                  onOpenChange(false);
+                  onOpenKeyboardShortcuts?.();
+                }}
+              >
+                <div className="flex items-center gap-3">
+                  <div className="text-muted-foreground"><Keyboard className="h-4 w-4" /></div>
+                  <span className="text-sm font-medium text-foreground">Keyboard Shortcuts</span>
+                </div>
+                <ExternalLink className="h-3.5 w-3.5 text-muted-foreground" />
+              </button>
+            )}
 
             {/* Daily Reviews */}
             <SettingsSection
@@ -386,8 +390,8 @@ export function SettingsDialog({ open, onOpenChange, onOpenKeyboardShortcuts, on
               title="Calendar"
               icon={<Calendar className="h-4 w-4" />}
             >
-              <SettingRow label="Week starts on" description="First day of the week" disabled>
-                <Select value={weekStartDay} onValueChange={setWeekStartDay}>
+              <SettingRow label="Week starts on" description="First day of the week">
+                <Select value={weekStartDay} onValueChange={(v) => setWeekStartDay(v as 'sunday' | 'monday' | 'saturday')}>
                   <SelectTrigger className="w-32 h-8 text-xs">
                     <SelectValue />
                   </SelectTrigger>
@@ -399,8 +403,8 @@ export function SettingsDialog({ open, onOpenChange, onOpenKeyboardShortcuts, on
                 </Select>
               </SettingRow>
 
-              <SettingRow label="Default view" description="View shown when app opens" disabled>
-                <Select defaultValue="day">
+              <SettingRow label="Default view" description="View shown when app opens">
+                <Select value={defaultView} onValueChange={(v) => setDefaultView(v as 'day' | 'week')}>
                   <SelectTrigger className="w-32 h-8 text-xs">
                     <SelectValue />
                   </SelectTrigger>
@@ -411,8 +415,8 @@ export function SettingsDialog({ open, onOpenChange, onOpenKeyboardShortcuts, on
                 </Select>
               </SettingRow>
 
-              <SettingRow label="Default time bucket" description="Where new tasks are placed" disabled>
-                <Select defaultValue="anytime">
+              <SettingRow label="Default time bucket" description="Where new tasks are placed">
+                <Select value={defaultTimeBucket} onValueChange={(v) => setDefaultTimeBucket(v as any)}>
                   <SelectTrigger className="w-32 h-8 text-xs">
                     <SelectValue />
                   </SelectTrigger>

--- a/components/planner/timeline.tsx
+++ b/components/planner/timeline.tsx
@@ -21,6 +21,7 @@ import { TIME_BUCKET_RANGES, formatBucketRange } from '@/lib/planner-types';
 import { cn } from '@/lib/utils';
 import { useDroppable, useDraggable } from '@dnd-kit/core';
 import { isSameDay, format } from 'date-fns';
+import { useTimeFormat } from '@/lib/use-time-format';
 
 const bucketConfig: Record<TimeBucket, {
   icon: typeof Clock;
@@ -994,7 +995,11 @@ function HourlyGrid({ bucket, scheduledTasks, scheduledHabits, onTaskClick, onHa
     return null;
   }
 
+  const timeFormatStr = useTimeFormat();
   const formatHour = (hour: number) => {
+    if (timeFormatStr === 'HH:mm') {
+      return `${String(hour).padStart(2, '0')}:00`;
+    }
     if (hour === 0) return '12am';
     if (hour < 12) return `${hour}am`;
     if (hour === 12) return '12pm';
@@ -1357,12 +1362,18 @@ interface TimelineProps {
 }
 
 export function Timeline({ onTaskClick, onHabitClick, onAddClick, activeId }: TimelineProps) {
-  const { tasks, habits, selectedDate, setSelectedDate, timelineItemFilter, setTimelineItemFilter, compactMode, chillMode, navDirection, setNavDirection } = usePlannerStore();
+  const { tasks, habits, selectedDate, setSelectedDate, timelineItemFilter, setTimelineItemFilter, compactMode, chillMode, navDirection, setNavDirection, showCompletedTasks } = usePlannerStore();
   const [currentBucket, setCurrentBucket] = useState<TimeBucket | null>(null);
   const [mounted, setMounted] = useState(false);
-  
+
   // Filter tasks and habits based on timeline filter
-  const filteredTasks = timelineItemFilter === 'habits' ? [] : tasks;
+  const filteredTasks = useMemo(() => {
+    let result = timelineItemFilter === 'habits' ? [] : tasks;
+    if (!showCompletedTasks) {
+      result = result.filter((t) => t.status !== 'completed');
+    }
+    return result;
+  }, [tasks, timelineItemFilter, showCompletedTasks]);
   const filteredHabits = timelineItemFilter === 'tasks' ? [] : habits;
 
   // Determine current time bucket and update every minute

--- a/components/planner/week-view.tsx
+++ b/components/planner/week-view.tsx
@@ -250,7 +250,7 @@ function DroppableCell({ dropId, children, className, disabled, glowColor }: Dro
 }
 
 export function WeekView({ onTaskClick, onHabitClick, onAddClick }: WeekViewProps) {
-  const { selectedDate, setSelectedDate, tasks, habits, projects, compactMode, chillMode, getProjectEmoji, getHabitGroupEmoji, timelineItemFilter, setTimelineItemFilter, showCurrentTimeIndicator } = usePlannerStore();
+  const { selectedDate, setSelectedDate, tasks, habits, projects, compactMode, chillMode, getProjectEmoji, getHabitGroupEmoji, timelineItemFilter, setTimelineItemFilter, showCurrentTimeIndicator, weekStartDay } = usePlannerStore();
 
   // Hover state for navigation
   const [prevWeekHovered, setPrevWeekHovered] = useState(false);
@@ -268,8 +268,9 @@ export function WeekView({ onTaskClick, onHabitClick, onAddClick }: WeekViewProp
     return () => clearInterval(id);
   }, []);
 
-  // Get the start of the week (Sunday)
-  const weekStart = useMemo(() => startOfWeek(selectedDate, { weekStartsOn: 0 }), [selectedDate]);
+  // Get the start of the week based on user preference
+  const weekStartsOn = weekStartDay === 'monday' ? 1 : weekStartDay === 'saturday' ? 6 : 0;
+  const weekStart = useMemo(() => startOfWeek(selectedDate, { weekStartsOn: weekStartsOn as 0 | 1 | 6 }), [selectedDate, weekStartsOn]);
   
   // Generate all 7 days of the week
   const weekDays = useMemo(() => {

--- a/components/providers/supabase-provider.tsx
+++ b/components/providers/supabase-provider.tsx
@@ -3,31 +3,79 @@
 import { useEffect } from 'react';
 import { createClient } from '@/lib/supabase';
 import { usePlannerStore } from '@/lib/planner-store';
+import { useSidebarStore } from '@/lib/sidebar-store';
+import { useMorningStore } from '@/lib/morning-store';
+import { loadSettings } from '@/lib/settings-service';
+import { useTheme } from 'next-themes';
 
 export function SupabaseProvider({ children }: { children: React.ReactNode }) {
   const initializeStore = usePlannerStore((s) => s.initializeStore);
   const clearStore = usePlannerStore((s) => s.clearStore);
+  const { setTheme } = useTheme();
+
+  // Apply animations setting to <html> element
+  const animationsEnabled = usePlannerStore((s) => s.animationsEnabled);
+  useEffect(() => {
+    const html = document.documentElement;
+    if (animationsEnabled) {
+      html.removeAttribute('data-reduce-motion');
+    } else {
+      html.setAttribute('data-reduce-motion', 'true');
+    }
+  }, [animationsEnabled]);
 
   useEffect(() => {
     const supabase = createClient();
+
+    const hydrateSettings = async (userId: string) => {
+      const settings = await loadSettings(userId);
+
+      usePlannerStore.setState({
+        compactMode: settings.compact_mode ?? false,
+        chillMode: settings.chill_mode ?? false,
+        showCurrentTimeIndicator: settings.show_time_indicator ?? true,
+        showCompletedTasks: settings.show_completed_tasks ?? true,
+        animationsEnabled: settings.animations_enabled ?? true,
+        weekStartDay: (settings.week_start_day as 'sunday' | 'monday' | 'saturday') ?? 'sunday',
+        defaultView: (settings.default_view as 'day' | 'week') ?? 'day',
+        defaultTimeBucket: (settings.default_time_bucket as any) ?? 'anytime',
+        timeFormat: (settings.time_format as '12h' | '24h') ?? '12h',
+        viewMode: (settings.default_view as 'day' | 'week') ?? 'day',
+      });
+
+      useSidebarStore.setState({
+        leftSidebarHoverEnabled: settings.left_sidebar_hover ?? false,
+        rightSidebarHoverEnabled: settings.right_sidebar_hover ?? false,
+      });
+
+      useMorningStore.setState({
+        morningCheckEnabled: settings.morning_check_enabled ?? true,
+      });
+
+      if (settings.theme) {
+        setTheme(settings.theme);
+      }
+    };
 
     // Check current session on mount
     supabase.auth.getSession().then(({ data: { session } }) => {
       if (session?.user) {
         initializeStore(session.user.id);
+        hydrateSettings(session.user.id);
       }
     });
 
     const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
       if (event === 'SIGNED_IN' && session?.user) {
         initializeStore(session.user.id);
+        hydrateSettings(session.user.id);
       } else if (event === 'SIGNED_OUT') {
         clearStore();
       }
     });
 
     return () => subscription.unsubscribe();
-  }, [initializeStore, clearStore]);
+  }, [initializeStore, clearStore, setTheme]);
 
   return <>{children}</>;
 }

--- a/lib/morning-store.ts
+++ b/lib/morning-store.ts
@@ -3,6 +3,8 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { format } from 'date-fns';
+import { saveSettings } from './settings-service';
+import { usePlannerStore } from './planner-store';
 
 interface MorningStore {
   dismissedDate: string | null; // yyyy-MM-dd
@@ -25,7 +27,11 @@ export const useMorningStore = create<MorningStore>()(
         return get().dismissedDate === today;
       },
 
-      setMorningCheckEnabled: (enabled) => set({ morningCheckEnabled: enabled }),
+      setMorningCheckEnabled: (enabled) => {
+        set({ morningCheckEnabled: enabled });
+        const userId = usePlannerStore.getState().userId;
+        if (userId) saveSettings(userId, { morning_check_enabled: enabled });
+      },
     }),
     {
       name: 'anchor-morning-store',

--- a/lib/planner-store.ts
+++ b/lib/planner-store.ts
@@ -35,6 +35,7 @@ import {
   updateHabitGroup as dbUpdateHabitGroup,
   deleteHabitGroup as dbDeleteHabitGroup,
 } from './db';
+import { saveSettings } from './settings-service';
 
 interface PlannerStore {
   tasks: Task[];
@@ -54,6 +55,18 @@ interface PlannerStore {
   setChillMode: (chill: boolean) => void;
   showCurrentTimeIndicator: boolean;
   setShowCurrentTimeIndicator: (show: boolean) => void;
+  showCompletedTasks: boolean;
+  setShowCompletedTasks: (show: boolean) => void;
+  defaultView: 'day' | 'week';
+  setDefaultView: (view: 'day' | 'week') => void;
+  defaultTimeBucket: TimeBucket;
+  setDefaultTimeBucket: (bucket: TimeBucket) => void;
+  animationsEnabled: boolean;
+  setAnimationsEnabled: (enabled: boolean) => void;
+  weekStartDay: 'sunday' | 'monday' | 'saturday';
+  setWeekStartDay: (day: 'sunday' | 'monday' | 'saturday') => void;
+  timeFormat: '12h' | '24h';
+  setTimeFormat: (format: '12h' | '24h') => void;
   /** ID of the task/habit card currently under the mouse cursor — used by keyboard shortcuts */
   hoveredItemId: string | null;
   hoveredItemType: 'task' | 'habit' | null;
@@ -236,13 +249,61 @@ export const usePlannerStore = create<PlannerStore>()(
         set({ actionLog: info.actionLog, historyIndex: info.currentIndex });
       },
       compactMode: false,
-      setCompactMode: (compact) => set({ compactMode: compact }),
+      setCompactMode: (compact) => {
+        set({ compactMode: compact });
+        const userId = get().userId;
+        if (userId) saveSettings(userId, { compact_mode: compact });
+      },
       navDirection: null,
       setNavDirection: (direction) => set({ navDirection: direction }),
       chillMode: false,
-      setChillMode: (chill) => set({ chillMode: chill }),
+      setChillMode: (chill) => {
+        set({ chillMode: chill });
+        const userId = get().userId;
+        if (userId) saveSettings(userId, { chill_mode: chill });
+      },
       showCurrentTimeIndicator: true,
-      setShowCurrentTimeIndicator: (show) => set({ showCurrentTimeIndicator: show }),
+      setShowCurrentTimeIndicator: (show) => {
+        set({ showCurrentTimeIndicator: show });
+        const userId = get().userId;
+        if (userId) saveSettings(userId, { show_time_indicator: show });
+      },
+      showCompletedTasks: true,
+      setShowCompletedTasks: (show) => {
+        set({ showCompletedTasks: show });
+        const userId = get().userId;
+        if (userId) saveSettings(userId, { show_completed_tasks: show });
+      },
+      defaultView: 'day',
+      setDefaultView: (view) => {
+        set({ defaultView: view, viewMode: view });
+        const userId = get().userId;
+        if (userId) saveSettings(userId, { default_view: view });
+      },
+      defaultTimeBucket: 'anytime',
+      setDefaultTimeBucket: (bucket) => {
+        set({ defaultTimeBucket: bucket });
+        const userId = get().userId;
+        if (userId) saveSettings(userId, { default_time_bucket: bucket });
+      },
+      animationsEnabled: true,
+      setAnimationsEnabled: (enabled) => {
+        set({ animationsEnabled: enabled });
+        const userId = get().userId;
+        if (userId) saveSettings(userId, { animations_enabled: enabled });
+      },
+      weekStartDay: 'sunday',
+      setWeekStartDay: (day) => {
+        set({ weekStartDay: day });
+        const userId = get().userId;
+        if (userId) saveSettings(userId, { week_start_day: day });
+      },
+      timeFormat: '12h',
+      setTimeFormat: (format) => {
+        set({ timeFormat: format });
+        const userId = get().userId;
+        if (userId) saveSettings(userId, { time_format: format });
+      },
       hoveredItemId: null,
       hoveredItemType: null,
       setHoveredItem: (id, type) => set({ hoveredItemId: id, hoveredItemType: type }),
@@ -665,7 +726,11 @@ export const usePlannerStore = create<PlannerStore>()(
       },
 
       setSelectedDate: (date) => set({ selectedDate: date }),
-      setViewMode: (viewMode) => set({ viewMode }),
+      setViewMode: (viewMode) => {
+        set({ viewMode, defaultView: viewMode });
+        const userId = get().userId;
+        if (userId) saveSettings(userId, { default_view: viewMode });
+      },
       setGroupBy: (groupBy) => set({ groupBy }),
       setFilters: (filters) => set({ filters }),
       clearFilters: () => set({ filters: {} }),
@@ -967,6 +1032,12 @@ export const usePlannerStore = create<PlannerStore>()(
         groupBy: state.groupBy,
         showCurrentTimeIndicator: state.showCurrentTimeIndicator,
         timelineItemFilter: state.timelineItemFilter,
+        showCompletedTasks: state.showCompletedTasks,
+        defaultView: state.defaultView,
+        defaultTimeBucket: state.defaultTimeBucket,
+        animationsEnabled: state.animationsEnabled,
+        weekStartDay: state.weekStartDay,
+        timeFormat: state.timeFormat,
       }),
     }
   )

--- a/lib/settings-service.ts
+++ b/lib/settings-service.ts
@@ -1,0 +1,73 @@
+import { createClient } from '@/lib/supabase';
+
+export interface UserSettingsRow {
+  theme?: string;
+  time_format?: string;
+  week_start_day?: string;
+  default_view?: string;
+  default_time_bucket?: string;
+  show_completed_tasks?: boolean;
+  animations_enabled?: boolean;
+  compact_mode?: boolean;
+  chill_mode?: boolean;
+  show_time_indicator?: boolean;
+  morning_check_enabled?: boolean;
+  left_sidebar_hover?: boolean;
+  right_sidebar_hover?: boolean;
+}
+
+const DEFAULT_SETTINGS: UserSettingsRow = {
+  theme: 'system',
+  time_format: '12h',
+  week_start_day: 'sunday',
+  default_view: 'day',
+  default_time_bucket: 'anytime',
+  show_completed_tasks: true,
+  animations_enabled: true,
+  compact_mode: false,
+  chill_mode: false,
+  show_time_indicator: true,
+  morning_check_enabled: true,
+  left_sidebar_hover: false,
+  right_sidebar_hover: false,
+};
+
+const SETTINGS_SELECT =
+  'theme,time_format,week_start_day,default_view,default_time_bucket,show_completed_tasks,animations_enabled,compact_mode,chill_mode,show_time_indicator,morning_check_enabled,left_sidebar_hover,right_sidebar_hover';
+
+export async function loadSettings(userId: string): Promise<UserSettingsRow> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('user_settings')
+    .select(SETTINGS_SELECT)
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) {
+    console.error('[settings] loadSettings error:', error.message);
+    return DEFAULT_SETTINGS;
+  }
+
+  if (!data) {
+    // First-time user — upsert defaults
+    await supabase
+      .from('user_settings')
+      .upsert({ user_id: userId, ...DEFAULT_SETTINGS }, { onConflict: 'user_id' });
+    return DEFAULT_SETTINGS;
+  }
+
+  return { ...DEFAULT_SETTINGS, ...data };
+}
+
+let _saveTimer: ReturnType<typeof setTimeout> | null = null;
+
+export function saveSettings(userId: string, patch: Partial<UserSettingsRow>): void {
+  if (_saveTimer) clearTimeout(_saveTimer);
+  _saveTimer = setTimeout(async () => {
+    const supabase = createClient();
+    const { error } = await supabase
+      .from('user_settings')
+      .upsert({ user_id: userId, ...patch }, { onConflict: 'user_id' });
+    if (error) console.error('[settings] saveSettings error:', error.message);
+  }, 500);
+}

--- a/lib/sidebar-store.ts
+++ b/lib/sidebar-store.ts
@@ -1,5 +1,7 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
+import { saveSettings } from './settings-service';
+import { usePlannerStore } from './planner-store';
 
 interface SidebarState {
   // Open/closed state
@@ -37,8 +39,16 @@ export const useSidebarStore = create<SidebarState>()(
       toggleRightSidebar: () => set((state) => ({ rightSidebarOpen: !state.rightSidebarOpen })),
       setLeftSidebarHovered: (hovered) => set({ leftSidebarHovered: hovered }),
       setRightSidebarHovered: (hovered) => set({ rightSidebarHovered: hovered }),
-      setLeftSidebarHoverEnabled: (enabled) => set({ leftSidebarHoverEnabled: enabled }),
-      setRightSidebarHoverEnabled: (enabled) => set({ rightSidebarHoverEnabled: enabled }),
+      setLeftSidebarHoverEnabled: (enabled) => {
+        set({ leftSidebarHoverEnabled: enabled });
+        const userId = usePlannerStore.getState().userId;
+        if (userId) saveSettings(userId, { left_sidebar_hover: enabled });
+      },
+      setRightSidebarHoverEnabled: (enabled) => {
+        set({ rightSidebarHoverEnabled: enabled });
+        const userId = usePlannerStore.getState().userId;
+        if (userId) saveSettings(userId, { right_sidebar_hover: enabled });
+      },
     }),
     {
       name: 'anchor-sidebar-settings',

--- a/lib/use-time-format.ts
+++ b/lib/use-time-format.ts
@@ -1,0 +1,11 @@
+import { usePlannerStore } from '@/lib/planner-store';
+
+/**
+ * Returns the date-fns format string for displaying times based on user preference.
+ * '12h' → 'h:mm a'   (e.g. "9:30 am")
+ * '24h' → 'HH:mm'    (e.g. "09:30")
+ */
+export function useTimeFormat(): string {
+  const timeFormat = usePlannerStore((s) => s.timeFormat);
+  return timeFormat === '24h' ? 'HH:mm' : 'h:mm a';
+}

--- a/supabase/migrations/008_settings.sql
+++ b/supabase/migrations/008_settings.sql
@@ -1,0 +1,15 @@
+-- 008_settings.sql
+alter table user_settings
+  add column if not exists theme                  text    default 'system',
+  add column if not exists time_format            text    default '12h',
+  add column if not exists week_start_day         text    default 'sunday',
+  add column if not exists default_view           text    default 'day',
+  add column if not exists default_time_bucket    text    default 'anytime',
+  add column if not exists show_completed_tasks   boolean default true,
+  add column if not exists animations_enabled     boolean default true,
+  add column if not exists compact_mode           boolean default false,
+  add column if not exists chill_mode             boolean default false,
+  add column if not exists show_time_indicator    boolean default true,
+  add column if not exists morning_check_enabled  boolean default true,
+  add column if not exists left_sidebar_hover     boolean default false,
+  add column if not exists right_sidebar_hover    boolean default false;


### PR DESCRIPTION
Closes #55, closes #60

## What's in this PR

### New settings wired up (removing 'Coming soon')
- **Theme** (light/dark/system) — connected to `next-themes` `setTheme()`; both top-nav toggle and settings selector stay in sync
- **Show completed tasks** — filters completed tasks from day/week timeline when off
- **Animations toggle** — sets `data-[reduce-motion]` on `<html>`; CSS transitions respect it
- **Time format** (12h/24h) — new `useTimeFormat()` hook, replaces hardcoded format strings
- **Week starts on** — threads through week-view header and `startOfWeek` calls
- **Default view** — read on app load to set initial tab
- **Default time bucket** — pre-selected in AddTaskDialog

### Supabase persistence
- New migration `008_settings.sql` — adds all settings columns to `user_settings`
- New `lib/settings-service.ts` — `loadSettings(userId)` + debounced `saveSettings(userId, patch)`
- All stores (`usePlannerStore`, `useSidebarStore`, `useMorningStore`) wired to save on change and hydrate from Supabase on auth

### UX
- Keyboard Shortcuts section hidden on mobile (touch devices, no keyboard)
- Still-disabled settings get honest labels: 'Requires push notifications' / 'Phase 2'

## Testing checklist
- [ ] Run migration `008_settings.sql` in Supabase
- [ ] Change theme → reload page → theme persists
- [ ] Toggle compact mode → reload → persists
- [ ] Toggle 'Show completed tasks' → completed tasks hide/show in timeline
- [ ] Change default view → reload → app opens on that view
- [ ] Change time format → time displays switch between 12h/24h
- [ ] Change week starts on → week view header updates
- [ ] Open settings on mobile → Keyboard Shortcuts section not visible
- [ ] Sign in on a different device/browser → settings sync from Supabase