### PR TITLE
fix: theme toggle flash + hide compact/chill mode on mobile

### DIFF
--- a/components/planner/settings-dialog.tsx
+++ b/components/planner/settings-dialog.tsx
@@ -218,19 +218,23 @@ export function SettingsDialog({ open, onOpenChange, onOpenKeyboardShortcuts, on
                 </Select>
               </SettingRow>
 
-              <SettingRow label="Compact mode" description="Fit more into the timeline with reduced spacing">
-                <Switch 
-                  checked={storeCompactMode} 
-                  onCheckedChange={setCompactMode}
-                />
-              </SettingRow>
+              {!isMobile && (
+                <SettingRow label="Compact mode" description="Fit more into the timeline with reduced spacing">
+                  <Switch 
+                    checked={storeCompactMode} 
+                    onCheckedChange={setCompactMode}
+                  />
+                </SettingRow>
+              )}
 
-              <SettingRow label="Chill mode" description="Hide extra UI elements until hovered for a calmer look">
-                <Switch 
-                  checked={chillMode} 
-                  onCheckedChange={setChillMode}
-                />
-              </SettingRow>
+              {!isMobile && (
+                <SettingRow label="Chill mode" description="Hide extra UI elements until hovered for a calmer look">
+                  <Switch 
+                    checked={chillMode} 
+                    onCheckedChange={setChillMode}
+                  />
+                </SettingRow>
+              )}
 
               <SettingRow label="Show completed tasks" description="Display completed tasks in timeline">
                 <Switch

--- a/components/providers/supabase-provider.tsx
+++ b/components/providers/supabase-provider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { createClient } from '@/lib/supabase';
 import { usePlannerStore } from '@/lib/planner-store';
 import { useSidebarStore } from '@/lib/sidebar-store';
@@ -12,6 +12,7 @@ export function SupabaseProvider({ children }: { children: React.ReactNode }) {
   const initializeStore = usePlannerStore((s) => s.initializeStore);
   const clearStore = usePlannerStore((s) => s.clearStore);
   const { setTheme } = useTheme();
+  const hydratedUserId = useRef<string | null>(null);
 
   // Apply animations setting to <html> element
   const animationsEnabled = usePlannerStore((s) => s.animationsEnabled);
@@ -28,6 +29,11 @@ export function SupabaseProvider({ children }: { children: React.ReactNode }) {
     const supabase = createClient();
 
     const hydrateSettings = async (userId: string) => {
+      // Skip if we've already hydrated for this user — prevents Supabase auth events
+      // (TOKEN_REFRESHED, duplicate SIGNED_IN) from overwriting user's in-session theme changes
+      if (hydratedUserId.current === userId) return;
+      hydratedUserId.current = userId;
+
       const settings = await loadSettings(userId);
 
       usePlannerStore.setState({
@@ -70,6 +76,7 @@ export function SupabaseProvider({ children }: { children: React.ReactNode }) {
         initializeStore(session.user.id);
         hydrateSettings(session.user.id);
       } else if (event === 'SIGNED_OUT') {
+        hydratedUserId.current = null;
         clearStore();
       }
     });


### PR DESCRIPTION
## What

Two quick fixes from our settings pass:

### Bug 1: Theme toggle flashes back after toggling
The `hydrateSettings` call in `supabase-provider.tsx` was firing multiple times — Supabase emits `SIGNED_IN` on initial session detection AND on token refresh (`TOKEN_REFRESHED`). If this fired within the 500ms debounce window after a user toggled the theme, it would re-apply the stale DB value, causing a flash back to the previous theme.

**Fix:** Track `hydratedUserId` via `useRef`. Skip re-hydration if we've already hydrated for the same user. Reset on sign-out.

### Bug 2: Compact Mode + Chill Mode shown on mobile (but don't work)
Both features rely on hover — Chill Mode literally shows/hides elements on hover. No hover on touch. Compact Mode works visually but mobile has its own optimized layout.

**Fix:** Wrap both `SettingRow`s in `!isMobile` guards in the settings dialog.

## Changes
- `components/providers/supabase-provider.tsx` — dedupe hydration by userId
- `components/planner/settings-dialog.tsx` — hide compact/chill on mobile