### PR TITLE
fix: serwist sw.js not generating on Vercel (async config + Turbopack conflict)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,5 @@
-import { PHASE_DEVELOPMENT_SERVER } from 'next/constants.js';
 import withSerwistInit from '@serwist/next';
+import { PHASE_DEVELOPMENT_SERVER } from 'next/constants.js';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -11,18 +11,10 @@ const nextConfig = {
   },
 };
 
-export default async function config(phase) {
-  // Only enable serwist in production / non-test builds to avoid SW interference in dev
-  if (phase === PHASE_DEVELOPMENT_SERVER) {
-    return nextConfig;
-  }
+const withSerwist = withSerwistInit({
+  swSrc: 'app/sw.ts',
+  swDest: 'public/sw.js',
+  disable: process.env.NODE_ENV === 'development',
+});
 
-  const withSerwist = withSerwistInit({
-    swSrc: 'app/sw.ts',
-    swDest: 'public/sw.js',
-    // Push-only — no precaching / offline caching in this PR
-    disable: false,
-  });
-
-  return withSerwist(nextConfig);
-}
+export default withSerwist(nextConfig);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint ."
   },


### PR DESCRIPTION
## Problem

`sw.js` was 404ing on the live Vercel deployment because the `next.config.mjs` used an async function wrapper for the serwist init. In Next.js 16, this prevents the webpack plugin from registering at build time, so the service worker file was never compiled.

Additionally, Next.js 16 defaults to Turbopack, which conflicts with serwist's webpack plugin and caused build failures.

## Fix

1. **Moved `withSerwistInit` outside the async function** — called synchronously at module level (standard serwist/next pattern). Used `process.env.NODE_ENV === 'development'` for the `disable` flag instead of the phase check.
2. **Added `--webpack` flag to the build script** in `package.json` — forces webpack bundler instead of Turbopack, which serwist requires.

## Result

`sw.js` is now correctly generated during build — confirmed locally with `npm run build`:
```
✓ (serwist) Bundling the service worker script with the URL '/sw.js' and the scope '/'...
```

Fixes the root cause of iOS push notification permission hanging indefinitely.