### PR TITLE
fix: EOD done toggle undo, time bucket drop targets, disable mobile DnD

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -48,7 +48,8 @@ import {
 import { Button } from '@/components/ui/button';
 import {
   DndContext,
-  closestCenter,
+  pointerWithin,
+  rectIntersection,
   PointerSensor,
   TouchSensor,
   useSensor,
@@ -60,6 +61,15 @@ import {
 } from '@dnd-kit/core';
 import { GripVertical, Circle, Keyboard as KeyboardIcon } from 'lucide-react';
 import { format } from 'date-fns';
+
+// Custom collision detection: prefer pointerWithin (exact pointer position inside droppable)
+// then fall back to closestCenter. This fixes time bucket drops being missed when the
+// dragged item's center is closer to a different droppable than the bucket under the pointer.
+function customCollisionDetection(args: Parameters<typeof pointerWithin>[0]) {
+  const pointerCollisions = pointerWithin(args);
+  if (pointerCollisions.length > 0) return pointerCollisions;
+  return rectIntersection(args);
+}
 
 function KbdHint() {
   const [isMac, setIsMac] = useState(false);
@@ -435,7 +445,7 @@ const handleAddFromTopNav = () => {
     <DndContext
       id="planner-dnd"
       sensors={sensors}
-      collisionDetection={closestCenter}
+      collisionDetection={customCollisionDetection}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
       measuring={{

--- a/components/ai/eod-review.tsx
+++ b/components/ai/eod-review.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useRef, useEffect } from 'react';
 import { format, addDays } from 'date-fns';
 import { Moon, CheckCircle2, Circle, ArrowRight, Sparkles, Check } from 'lucide-react';
 import {
@@ -47,14 +47,26 @@ export function EODReview() {
 
   const today = todayStr();
 
-  // Partition today's tasks
-  const { completedTasks, pendingTasks } = useMemo(() => {
+  // Partition today's tasks — live view for completed section
+  const { completedTasks, pendingTasks: livePendingTasks } = useMemo(() => {
     const todayTasks = tasks.filter((t) => t.startDate === today && t.status !== 'cancelled');
     return {
       completedTasks: todayTasks.filter((t) => t.status === 'completed'),
       pendingTasks: todayTasks.filter((t) => t.status === 'pending'),
     };
   }, [tasks, today]);
+
+  // Snapshot pendingTasks when the dialog opens so tasks marked done during
+  // the session don't disappear from the list (we need the circle to stay
+  // visible so the user can undo).
+  const snapshotRef = useRef<typeof livePendingTasks>([]);
+  useEffect(() => {
+    if (isOpen) {
+      snapshotRef.current = livePendingTasks;
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+  const pendingTasks = isOpen ? snapshotRef.current : livePendingTasks;
 
   // Partition today's habits
   const { doneHabits, skippedHabits } = useMemo(() => {
@@ -70,7 +82,7 @@ export function EODReview() {
 
   // Which pending tasks the user has checked to carry forward
   const [selectedIds, setSelectedIds] = useState<Set<string>>(
-    () => new Set(pendingTasks.map((t) => t.id))
+    () => new Set(livePendingTasks.map((t) => t.id))
   );
 
   // Tasks marked complete during this EOD session

--- a/components/mobile/mobile-tasks-panel.tsx
+++ b/components/mobile/mobile-tasks-panel.tsx
@@ -89,8 +89,10 @@ function MobileTaskItem({ task, onClick }: { task: Task; onClick: () => void }) 
     setNodeRef,
     transform,
     isDragging,
-  } = useDraggable({ id: task.id });
+  } = useDraggable({ id: task.id, disabled: true });
 
+  // DnD is disabled in the mobile To Do tab — there's nowhere to drag to across tabs.
+  // Re-enable (set disabled: false) in Phase 2 when within-list reorder is added (issue #89).
   const style = transform ? {
     transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`,
   } : undefined;


### PR DESCRIPTION
## What's fixed

### Bug 1 — EOD Review: undo done toggle not working
The pending task list was driven by a live `useMemo` from the store. When a task was marked done, it immediately moved from `pendingTasks` to `completedTasks` — so the circle button disappeared before the user could click it again to undo.

**Fix:** Snapshot `pendingTasks` into a `useRef` when the dialog opens (`isOpen` goes true). The dialog renders from the snapshot for the duration of the session, so marked-done tasks stay visible with their circle. The visual state (strikethrough, green fill) is driven by `justCompletedIds` as before.

### Bug 2 — Time buckets not valid drop targets on Desktop Day view
The DnD collision detection was using `closestCenter`, which finds the droppable whose center is closest to the dragged item's center. For large bucket containers, this often meant a different droppable won the collision check even when the pointer was physically inside the bucket.

**Fix:** Custom collision detection that tries `pointerWithin` first (exact pointer position inside droppable rect), falling back to `rectIntersection` for edge cases. This makes bucket drops work reliably regardless of where in the bucket the pointer is.

### Bug 3 — Disable DnD on mobile To Do tab
Tasks in the mobile To Do tab had DnD enabled with no valid drop targets (Schedule is a separate tab). Added `disabled: true` to `useDraggable` in `MobileTasksPanel`.

Left a comment pointing to issue #89 for Phase 2 within-list reorder re-enable.

## Testing
- Build passes ✅
- Manual test: EOD toggle undo, time bucket drop, mobile To Do drag (disabled)