### PR TITLE
ci: run E2E tests only on PRs and manual dispatch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
     name: E2E tests (Playwright)
     runs-on: ubuntu-latest
     continue-on-error: true
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     env:
       NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
       NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}


### PR DESCRIPTION
Unit tests still run on every push to any branch. E2E (Playwright) now only runs on PRs targeting main, or when manually triggered via workflow_dispatch. This keeps branch pushes fast while still protecting main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to refine test execution conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->