### PR TITLE
fix: include user timezone in Anchor context header

### DIFF
--- a/openclaw-plugin/src/context.ts
+++ b/openclaw-plugin/src/context.ts
@@ -21,7 +21,7 @@ export function buildHeader(): string {
   const overdue = pending.filter((t) => t.startDate && t.startDate < today)
   const todayTasks = pending.filter((t) => !t.startDate || t.startDate === today)
   const pendingHabits = cache.habits.filter((h) => h.status === 'pending')
-  return `[Anchor: ${todayTasks.length} tasks today, ${overdue.length} overdue, ${pendingHabits.length} habits pending — say "what are my current tasks?" for details]`
+  return `[Anchor: ${todayTasks.length} tasks today, ${overdue.length} overdue, ${pendingHabits.length} habits pending | tz: ${timezone} | say "what are my current tasks?" for details]`
 }
 
 /** ~200–400 tokens — injected on planning-related messages */


### PR DESCRIPTION
## Summary

Adds `tz: <timezone>` to the always-injected Anchor context header so the AI agent always sees the user's local timezone before making any date-related tool calls.

**Before:**
`[Anchor: 10 tasks today, 0 overdue, 1 habits pending — say "what are my current tasks?" for details]`

**After:**
`[Anchor: 10 tasks today, 0 overdue, 1 habits pending | tz: America/Los_Angeles | say "what are my current tasks?" for details]`

## Why

Without this, the agent defaults to UTC when deciding what date to pass to `anchor_create_task` etc. For a user in PDT (UTC-7), a task created "tonight" at 11pm could land on the wrong date. The timezone is already in the cache (fetched from `user_settings` by the API) — this just surfaces it in the header where the agent can see it on every turn.

This is automatic for all users — the plugin fetches `userTimezone` from the API on startup and uses it for all date math. No user configuration needed.

## Related
- #100 (plugin tool registration — this header now ensures date args are correct)
- #121 (Supabase Realtime — once live, task writes will also update the UI without a reload)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The header now displays the user's timezone information alongside task and habit summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->