### PR TITLE
fix(tests): inject Supabase session via cookies in E2E auth helper

### DIFF
--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -1,16 +1,30 @@
 import type { Page } from '@playwright/test';
 
 /**
- * Log in the test user by calling Supabase's REST API directly, then
- * injecting the session via the Supabase JS client inside the browser context.
+ * Log in the test user by calling Supabase's REST API directly in Node, then
+ * injecting the session into the browser context as cookies — no UI, no magic
+ * link, no page.evaluate() imports.
  *
- * This bypasses the login UI entirely — all E2E specs that aren't specifically
+ * This bypasses the login UI entirely. All E2E specs that are not specifically
  * testing the authentication flow (magic link, OAuth, etc.) should use this.
  *
- * Why not localStorage? The app uses @supabase/ssr's createBrowserClient, which
- * stores sessions in cookies (not localStorage). We get tokens from the REST API
- * and then call supabase.auth.setSession() inside the page so the SDK writes the
- * cookies itself — no manual cookie construction needed.
+ * Why cookies instead of page.evaluate + import?
+ * @supabase/ssr persists sessions in cookies (not localStorage). The previous
+ * implementation tried to `import("@supabase/ssr")` inside page.evaluate(),
+ * but Playwright's browser context cannot resolve Node modules — it throws
+ * "TypeError: Failed to resolve module specifier @supabase/ssr".
+ *
+ * The fix: call the Supabase password auth REST endpoint from Node (using
+ * page.request, which runs in Node), encode the returned session exactly the
+ * way @supabase/ssr would (base64url, chunked at 3 180 bytes), and inject the
+ * resulting cookies via page.context().addCookies() before the first navigation.
+ * The server-side Supabase client picks them up on the very first request.
+ *
+ * Cookie encoding details (matches @supabase/ssr v0.9 defaults):
+ *   name:  sb-<project-ref>-auth-token  (project-ref = URL subdomain)
+ *   value: "base64-" + base64url( UTF-8( JSON.stringify(session) ) )
+ *   chunked into multiple cookies (sb-…-auth-token.0, .1, …) if the
+ *   URI-encoded value exceeds MAX_CHUNK_SIZE (3 180 bytes).
  *
  * For real auth flow tests, see: https://github.com/kjswalls/v0-anchor/issues/117
  *
@@ -32,7 +46,8 @@ export async function loginTestUser(page: Page): Promise<void> {
     );
   }
 
-  // 1. Get tokens from Supabase REST API (no UI, no magic link)
+  // 1. Exchange credentials for tokens via the Supabase REST API.
+  //    page.request runs in Node, so it can reach the Supabase origin directly.
   const response = await page.request.post(
     `${supabaseUrl}/auth/v1/token?grant_type=password`,
     {
@@ -46,28 +61,87 @@ export async function loginTestUser(page: Page): Promise<void> {
 
   if (!response.ok()) {
     const body = await response.text();
-    throw new Error(`Supabase signInWithPassword failed (${response.status()}): ${body}`);
+    throw new Error(
+      `Supabase signInWithPassword failed (${response.status()}): ${body}`
+    );
   }
 
   const session = await response.json();
-  const { access_token, refresh_token } = session;
 
-  // 2. Navigate to the app so window/document are available
+  // 2. Derive the cookie base name.
+  //    @supabase/ssr defaults to `sb-<ref>-auth-token` where <ref> is the
+  //    first segment of the Supabase hostname (the project reference ID).
+  const ref = new URL(supabaseUrl).hostname.split('.')[0];
+  const cookieBaseName = `sb-${ref}-auth-token`;
+
+  // 3. Encode the session the same way @supabase/ssr does by default
+  //    (cookieEncoding: "base64url"):
+  //      encoded = "base64-" + base64url( UTF-8( JSON.stringify(session) ) )
+  //    Node's Buffer base64url encoding is byte-for-byte identical to
+  //    @supabase/ssr's stringToBase64URL() — both convert the JS string to
+  //    UTF-8 bytes then base64url-encode without padding.
+  const cookieValue = `base64-${Buffer.from(JSON.stringify(session)).toString('base64url')}`;
+
+  // 4. Chunk the value if it exceeds @supabase/ssr's MAX_CHUNK_SIZE.
+  //    The library checks the *URI-encoded* length (encodeURIComponent) against
+  //    3 180 bytes before deciding to chunk. Because the base64url alphabet is
+  //    entirely URL-safe, encodeURIComponent won't inflate the value, so the
+  //    check is effectively on the raw length.
+  //
+  //    Single chunk  → cookie named exactly `cookieBaseName`
+  //    Multiple chunks → cookies named `cookieBaseName.0`, `.1`, `.2`, …
+  const MAX_CHUNK_SIZE = 3180;
+  const encodedValue = encodeURIComponent(cookieValue);
+
+  // ~400-day expiry, matching DEFAULT_COOKIE_OPTIONS.maxAge in @supabase/ssr
+  const expires = Math.floor(Date.now() / 1000) + 400 * 24 * 60 * 60;
+  const cookieDefaults = {
+    domain: 'localhost',
+    path: '/',
+    httpOnly: false, // @supabase/ssr browser client reads cookies from JS
+    secure: false,   // http in local dev / CI
+    sameSite: 'Lax' as const,
+    expires,
+  };
+
+  const cookies: Array<typeof cookieDefaults & { name: string; value: string }> = [];
+
+  if (encodedValue.length <= MAX_CHUNK_SIZE) {
+    // Common case: entire session fits in one cookie.
+    cookies.push({ ...cookieDefaults, name: cookieBaseName, value: cookieValue });
+  } else {
+    // Large session: replicate @supabase/ssr's chunker (chunker.ts:createChunks).
+    // Split along URI-encoded boundaries so we never cut inside a %-sequence.
+    let remaining = encodedValue;
+    let i = 0;
+
+    while (remaining.length > 0) {
+      let head = remaining.slice(0, MAX_CHUNK_SIZE);
+
+      // If the last %-encoded sequence is truncated, back up to exclude it.
+      const lastPct = head.lastIndexOf('%');
+      if (lastPct > MAX_CHUNK_SIZE - 3) {
+        head = head.slice(0, lastPct);
+      }
+
+      cookies.push({
+        ...cookieDefaults,
+        name: `${cookieBaseName}.${i}`,
+        value: decodeURIComponent(head),
+      });
+
+      remaining = remaining.slice(head.length);
+      i++;
+    }
+  }
+
+  // 5. Inject the session cookies into the browser context before navigation.
+  //    The server-side Supabase client (middleware / RSC) reads them on the
+  //    very first request — no page.evaluate(), no Node module imports needed.
+  await page.context().addCookies(cookies);
+
+  // 6. Navigate to the app. The cookies are already present, so the server
+  //    hydrates the session on this first request — no reload required.
   await page.goto('/');
-
-  // 3. Call supabase.auth.setSession() inside the browser — the SDK writes
-  //    the session to cookies itself, which is what @supabase/ssr reads.
-  await page.evaluate(
-    async ({ url, key, accessToken, refreshToken }) => {
-      const { createBrowserClient } = await import('@supabase/ssr');
-      const supabase = createBrowserClient(url, key);
-      const { error } = await supabase.auth.setSession({ access_token: accessToken, refresh_token: refreshToken });
-      if (error) throw new Error(`setSession failed: ${error.message}`);
-    },
-    { url: supabaseUrl, key: anonKey, accessToken: access_token, refreshToken: refresh_token }
-  );
-
-  // 4. Reload so the app's SupabaseProvider hydrates with the session from cookies
-  await page.reload();
   await page.waitForURL('/');
 }


### PR DESCRIPTION
## Problem
The E2E auth helper tried to `import('@supabase/ssr')` inside `page.evaluate()`, but Playwright's browser context can't resolve Node modules. All 18 E2E tests were failing with:
```
TypeError: Failed to resolve module specifier '@supabase/ssr'
```

## Fix
- Call Supabase password auth REST API from Node (`page.request`)
- Encode the session as `base64-<base64url>` matching `@supabase/ssr`'s cookie format exactly
- Inject via `page.context().addCookies()` before navigation — no `page.evaluate()` needed
- Handles chunked cookies for large sessions (matches `@supabase/ssr` chunker logic)

## Result
Auth helper should now successfully log in the test user, unblocking all 18 E2E specs.

Closes #128 (partial — auth is unblocked, specs still need implementations)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved authentication test setup workflow in end-to-end tests for better reliability and performance during session initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->