### PR TITLE
fix(api): wrap all agent write routes in try/catch for readable 500 errors

### DIFF
--- a/app/api/agent/habit-groups/[id]/route.ts
+++ b/app/api/agent/habit-groups/[id]/route.ts
@@ -40,10 +40,14 @@ export async function PATCH(
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }
 
-  const updates: Partial<HabitGroupType> = await req.json()
-  await updateHabitGroup(userId, id, updates, serviceClient)
-
-  return NextResponse.json({ success: true })
+  try {
+    const updates: Partial<HabitGroupType> = await req.json()
+    await updateHabitGroup(userId, id, updates, serviceClient)
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Internal server error'
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
 }
 
 /**
@@ -81,7 +85,11 @@ export async function DELETE(
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }
 
-  await deleteHabitGroup(userId, id, serviceClient)
-
-  return NextResponse.json({ success: true })
+  try {
+    await deleteHabitGroup(userId, id, serviceClient)
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Internal server error'
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
 }

--- a/app/api/agent/habits/[id]/route.ts
+++ b/app/api/agent/habits/[id]/route.ts
@@ -40,10 +40,14 @@ export async function PATCH(
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }
 
-  const updates: Partial<Habit> = await req.json()
-  await updateHabit(id, updates, userId, serviceClient)
-
-  return NextResponse.json({ success: true })
+  try {
+    const updates: Partial<Habit> = await req.json()
+    await updateHabit(id, updates, userId, serviceClient)
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Internal server error'
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
 }
 
 /**
@@ -81,7 +85,11 @@ export async function DELETE(
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }
 
-  await deleteHabit(id, userId, serviceClient)
-
-  return NextResponse.json({ success: true })
+  try {
+    await deleteHabit(id, userId, serviceClient)
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Internal server error'
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
 }

--- a/app/api/agent/habits/route.ts
+++ b/app/api/agent/habits/route.ts
@@ -29,28 +29,33 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const serviceClient = createServiceClient()
-  const body = await req.json()
+  try {
+    const serviceClient = createServiceClient()
+    const body = await req.json()
 
-  const habit: Habit = {
-    id: body.id ?? crypto.randomUUID(),
-    title: body.title,
-    group: body.group,
-    streak: body.streak ?? 0,
-    status: body.status,
-    repeatFrequency: body.repeatFrequency,
-    completedDates: body.completedDates ?? [],
-    skippedDates: body.skippedDates ?? [],
-    dailyCounts: body.dailyCounts ?? {},
-    timeBucket: body.timeBucket,
-    startTime: body.startTime,
-    repeatDays: body.repeatDays,
-    repeatMonthDay: body.repeatMonthDay,
-    timesPerDay: body.timesPerDay,
-    currentDayCount: body.currentDayCount,
+    const habit: Habit = {
+      id: body.id ?? crypto.randomUUID(),
+      title: body.title,
+      group: body.group,
+      streak: body.streak ?? 0,
+      status: body.status,
+      repeatFrequency: body.repeatFrequency,
+      completedDates: body.completedDates ?? [],
+      skippedDates: body.skippedDates ?? [],
+      dailyCounts: body.dailyCounts ?? {},
+      timeBucket: body.timeBucket,
+      startTime: body.startTime,
+      repeatDays: body.repeatDays,
+      repeatMonthDay: body.repeatMonthDay,
+      timesPerDay: body.timesPerDay,
+      currentDayCount: body.currentDayCount,
+    }
+
+    await createHabit(userId, habit, serviceClient)
+
+    return NextResponse.json({ habit }, { status: 201 })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Internal server error'
+    return NextResponse.json({ error: msg }, { status: 500 })
   }
-
-  await createHabit(userId, habit, serviceClient)
-
-  return NextResponse.json({ habit }, { status: 201 })
 }

--- a/app/api/agent/projects/[id]/route.ts
+++ b/app/api/agent/projects/[id]/route.ts
@@ -40,10 +40,14 @@ export async function PATCH(
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }
 
-  const updates: Partial<Project> = await req.json()
-  await updateProject(userId, id, updates, serviceClient)
-
-  return NextResponse.json({ success: true })
+  try {
+    const updates: Partial<Project> = await req.json()
+    await updateProject(userId, id, updates, serviceClient)
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Internal server error'
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
 }
 
 /**
@@ -81,7 +85,11 @@ export async function DELETE(
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }
 
-  await deleteProject(userId, id, serviceClient)
-
-  return NextResponse.json({ success: true })
+  try {
+    await deleteProject(userId, id, serviceClient)
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Internal server error'
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
 }

--- a/app/api/agent/tasks/[id]/route.ts
+++ b/app/api/agent/tasks/[id]/route.ts
@@ -40,10 +40,14 @@ export async function PATCH(
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }
 
-  const updates: Partial<Task> = await req.json()
-  await updateTask(id, updates, userId, serviceClient)
-
-  return NextResponse.json({ success: true })
+  try {
+    const updates: Partial<Task> = await req.json()
+    await updateTask(id, updates, userId, serviceClient)
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Internal server error'
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
 }
 
 /**
@@ -81,7 +85,11 @@ export async function DELETE(
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }
 
-  await deleteTask(id, userId, serviceClient)
-
-  return NextResponse.json({ success: true })
+  try {
+    await deleteTask(id, userId, serviceClient)
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Internal server error'
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
 }

--- a/app/api/agent/tasks/route.ts
+++ b/app/api/agent/tasks/route.ts
@@ -27,27 +27,32 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const serviceClient = createServiceClient()
-  const body = await req.json()
+  try {
+    const serviceClient = createServiceClient()
+    const body = await req.json()
 
-  const task: Task = {
-    id: body.id ?? crypto.randomUUID(),
-    title: body.title,
-    status: body.status,
-    isScheduled: body.isScheduled,
-    order: body.order,
-    priority: body.priority,
-    project: body.project,
-    startDate: body.startDate,
-    timeBucket: body.timeBucket,
-    startTime: body.startTime,
-    duration: body.duration,
-    repeatFrequency: body.repeatFrequency,
-    repeatDays: body.repeatDays,
-    repeatMonthDay: body.repeatMonthDay,
+    const task: Task = {
+      id: body.id ?? crypto.randomUUID(),
+      title: body.title,
+      status: body.status,
+      isScheduled: body.isScheduled,
+      order: body.order,
+      priority: body.priority,
+      project: body.project,
+      startDate: body.startDate,
+      timeBucket: body.timeBucket,
+      startTime: body.startTime,
+      duration: body.duration,
+      repeatFrequency: body.repeatFrequency,
+      repeatDays: body.repeatDays,
+      repeatMonthDay: body.repeatMonthDay,
+    }
+
+    await createTask(userId, task, serviceClient)
+
+    return NextResponse.json({ task }, { status: 201 })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Internal server error'
+    return NextResponse.json({ error: msg }, { status: 500 })
   }
-
-  await createTask(userId, task, serviceClient)
-
-  return NextResponse.json({ task }, { status: 201 })
 }


### PR DESCRIPTION
All 8 agent write route handlers were missing try/catch, so any DB error from Supabase would result in a blank 500 response with no body. This makes debugging impossible in CI.

Wraps the DB operation in every handler (POST tasks/habits, PATCH/DELETE tasks/habits/projects/habit-groups) so errors surface as `{ error: "message" }` JSON instead of silent 500s.

Part of the test suite debugging chain for #128.