### PR TITLE
fix: left sidebar scrollable on desktop (#92)

### DIFF
--- a/components/planner/task-sidebar.tsx
+++ b/components/planner/task-sidebar.tsx
@@ -569,8 +569,8 @@ export function TaskSidebar({ onTaskClick, onHabitClick, onAddClick, onAddHabitC
       <aside 
         ref={setDroppableRef}
         className={cn(
-          'border-r border-border bg-sidebar flex flex-col h-full transition-all duration-300',
-          isVisible ? 'w-80' : 'w-0 border-r-0 overflow-hidden',
+          'border-r border-border bg-sidebar flex flex-col h-full overflow-hidden transition-all duration-300',
+          isVisible ? 'w-80' : 'w-0 border-r-0',
           leftSidebarHovered && !leftSidebarOpen && 'shadow-xl z-20 absolute left-0 top-0 bottom-0',
           isOver && 'bg-primary/5 border-primary'
         )}


### PR DESCRIPTION
## Summary

The left sidebar wasn't scrollable on desktop because `overflow-hidden` was only applied in the collapsed (`w-0`) state. The expanded aside had no overflow constraint, so `ScrollArea flex-1` couldn't establish a bounded scroll region.

## Fix

Move `overflow-hidden` to the base `aside` classes so it applies at all times. Cleaned up the now-redundant `overflow-hidden` from the collapsed state.

## Testing

- Open sidebar on desktop with many tasks/habits — should scroll smoothly
- Mobile is unaffected (uses `MobileTasksPanel` component)

Closes #92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved left sidebar overflow behavior for consistent visual handling across expanded and collapsed states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->