### PR TITLE
fix: sidebar scroll min-h-0 follow-up (#92)

### DIFF
--- a/components/mobile/mobile-tasks-panel.tsx
+++ b/components/mobile/mobile-tasks-panel.tsx
@@ -691,7 +691,7 @@ export function MobileTasksPanel({ onTaskClick, onHabitClick, onAddClick, onAddH
             )}
           </div>
 
-          <ScrollArea className="flex-1">
+          <ScrollArea className="flex-1 min-h-0">
             <div className="p-3 space-y-4">
               {Object.entries(groupedTasks).map(([groupName, groupTasks]) => (
                 <div key={groupName}>
@@ -779,7 +779,7 @@ export function MobileTasksPanel({ onTaskClick, onHabitClick, onAddClick, onAddH
             </div>
           </div>
 
-          <ScrollArea className="flex-1">
+          <ScrollArea className="flex-1 min-h-0">
             <div className="p-3 space-y-4">
               {Object.entries(groupedHabits).map(([groupName, groupHabits]) => (
                 <div key={groupName}>

--- a/components/planner/task-sidebar.tsx
+++ b/components/planner/task-sidebar.tsx
@@ -569,8 +569,8 @@ export function TaskSidebar({ onTaskClick, onHabitClick, onAddClick, onAddHabitC
       <aside 
         ref={setDroppableRef}
         className={cn(
-          'border-r border-border bg-sidebar flex flex-col h-full overflow-hidden transition-all duration-300',
-          isVisible ? 'w-80' : 'w-0 border-r-0',
+          'border-r border-border bg-sidebar flex flex-col h-full transition-all duration-300',
+          isVisible ? 'w-80' : 'w-0 border-r-0 overflow-hidden',
           leftSidebarHovered && !leftSidebarOpen && 'shadow-xl z-20 absolute left-0 top-0 bottom-0',
           isOver && 'bg-primary/5 border-primary'
         )}
@@ -680,7 +680,7 @@ export function TaskSidebar({ onTaskClick, onHabitClick, onAddClick, onAddHabitC
             )}
           </div>
 
-          <ScrollArea className="flex-1">
+          <ScrollArea className="flex-1 min-h-0">
             <div className="p-3 space-y-4">
               {Object.entries(groupedTasks).map(([groupName, groupTasks]) => (
                 <div key={groupName}>
@@ -790,7 +790,7 @@ export function TaskSidebar({ onTaskClick, onHabitClick, onAddClick, onAddHabitC
             )}
           </div>
 
-          <ScrollArea className="flex-1">
+          <ScrollArea className="flex-1 min-h-0">
             <div className="p-3 space-y-4">
               {Object.entries(groupedHabits).map(([groupName, groupHabits]) => (
                 <div key={groupName}>


### PR DESCRIPTION
Follow-up to #155 — the original fix used `overflow-hidden` which clips content instead of enabling scroll. The real fix is `min-h-0` on the `ScrollArea` components.

## Root cause
In a flex column, `flex-1` expands to fill space but doesn't cap the element's minimum height. Without `min-h-0`, `ScrollArea` grows as tall as its content instead of scrolling.

## Fix
Add `min-h-0` to all 4 `ScrollArea` instances:
- `components/planner/task-sidebar.tsx` — tasks + habits panes (desktop)
- `components/mobile/mobile-tasks-panel.tsx` — tasks + habits panes (mobile)

Closes #92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scrolling behavior in Tasks and Habits panels on mobile devices for a smoother and more responsive experience
  * Improved scroll container layout in Task Sidebar to ensure visual stability and proper content display across different screen sizes
  * Resolved scroll area sizing issues that could occur when components are nested in flexible container layouts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->