### PR TITLE
fix: recurring tasks not showing on future dates on mobile

### DIFF
--- a/components/mobile/mobile-schedule-panel.tsx
+++ b/components/mobile/mobile-schedule-panel.tsx
@@ -535,18 +535,14 @@ export function MobileSchedulePanel({ onTaskClick, onHabitClick, onAddClick, act
           if (selectedDateStr !== toDateStr(new Date(), resolvedTimezone)) return;
         } else if (isRecurring(task)) {
           // Recurring tasks: show if recurrence matches AND startDate ≤ selectedDate
-          const taskStartDateStr = task.startDate.includes("T")
-            ? task.startDate.split("T")[0]
-            : task.startDate;
+          const taskStartDateStr = toDateStr(new Date(task.startDate), resolvedTimezone);
           if (!shouldShowOnDate(task, selectedDateStr, resolvedTimezone)) return;
           if (taskStartDateStr > selectedDateStr) return;
           // Exclude if completed on this date and showCompletedTasks is false
           if (!showCompletedTasks && isCompletedOnDate(task, selectedDateStr)) return;
         } else {
           // One-off tasks: exact date match
-          const taskStartDateStr = task.startDate.includes("T")
-            ? task.startDate.split("T")[0]
-            : task.startDate;
+          const taskStartDateStr = toDateStr(new Date(task.startDate), resolvedTimezone);
           if (taskStartDateStr !== selectedDateStr) return;
         }
         buckets[task.timeBucket].tasks.push(task);


### PR DESCRIPTION
## Summary

- **Bug:** `mobile-schedule-panel.tsx` used a naive exact-date match (`task.startDate !== selectedDateStr`) to filter tasks in the `scheduledItems` useMemo. A recurring task created on April 6 with `repeatFrequency: "daily"` would be filtered out on April 7+ because its `startDate` never equals the selected date string.
- **Fix:** Replaced the naive check with recurrence-aware filtering that mirrors the logic already used in the desktop `timeline.tsx`. Recurring tasks now go through `shouldShowOnDate()` + `isCompletedOnDate()` from `lib/recurrence.ts`, while one-off tasks retain the exact date match and unscheduled tasks continue to show only on today.
- **Note:** Caught during mobile testing of PR #160 changes (task recurrence propagation).

## Test plan

- [ ] Create a daily recurring task scheduled for today — verify it appears in mobile schedule view
- [ ] Navigate to tomorrow — verify the recurring task still appears
- [ ] Navigate to a date before the task's `startDate` — verify it does NOT appear
- [ ] Mark the recurring task complete on one day — verify it is hidden on that day when "show completed" is off
- [ ] Verify one-off tasks still only appear on their exact scheduled date

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Mobile schedule now respects the user’s timezone with a browser fallback for accurate date handling.
  * Task filtering refined so unscheduled, recurring, and one‑off tasks appear on the correct selected dates.
  * Completed-task visibility now follows the schedule view setting, preventing completed items from appearing on the selected date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->