### PR TITLE
fix: mobile task date off-by-one (UTC timezone shift)

### DIFF
--- a/components/mobile/mobile-schedule-panel.tsx
+++ b/components/mobile/mobile-schedule-panel.tsx
@@ -544,14 +544,16 @@ export function MobileSchedulePanel({ onTaskClick, onHabitClick, onAddClick, act
           if (selectedDateStr !== todayDateStr) return;
         } else if (isRecurring(task)) {
           // Recurring tasks: show if recurrence matches AND startDate ≤ selectedDate
-          const taskStartDateStr = toDateStr(new Date(task.startDate), resolvedTimezone);
+          // Use .split('T')[0] to avoid UTC-midnight timezone shift when parsing date-only strings
+          const taskStartDateStr = task.startDate.split('T')[0];
           if (!shouldShowOnDate(task, selectedDateStr, resolvedTimezone)) return;
           if (taskStartDateStr > selectedDateStr) return;
           // Exclude if completed on this date and showCompletedTasks is false
           if (!showCompletedTasks && isCompletedOnDate(task, selectedDateStr)) return;
         } else {
           // One-off tasks: exact date match
-          const taskStartDateStr = toDateStr(new Date(task.startDate), resolvedTimezone);
+          // Use .split('T')[0] to avoid UTC-midnight timezone shift when parsing date-only strings
+          const taskStartDateStr = task.startDate.split('T')[0];
           if (taskStartDateStr !== selectedDateStr) return;
         }
         buckets[task.timeBucket].tasks.push(task);


### PR DESCRIPTION
## Bug
Tasks assigned to today showed on the previous day on mobile (and recurring tasks also appeared one day too early as their start boundary).

## Root Cause
`new Date('YYYY-MM-DD')` parses a date-only string as **UTC midnight**. In PDT (UTC-7), that's 5pm the previous evening — so `toDateStr(new Date(task.startDate), userTimezone)` returned yesterday's date instead of today's.

This affected two spots in `scheduledItems` useMemo:
- Recurring task `startDate ≤ selectedDate` boundary check
- One-off task exact date match

## Fix
Use `task.startDate.split('T')[0]` — same pattern desktop `timeline.tsx` already uses. Avoids `Date` parsing entirely for date-only strings, so no UTC shift possible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date filtering for recurring and one-off tasks in the mobile schedule panel to ensure accurate display on intended dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->