### PR TITLE
chore(plugin): export resetCacheState() for unit testing

### DIFF
--- a/openclaw-plugin/src/cache.ts
+++ b/openclaw-plugin/src/cache.ts
@@ -71,3 +71,10 @@ export async function fetchContext(cfg: PluginConfig): Promise<void> {
     fetchedAt: Date.now(),
   }
 }
+
+/** Test helper — resets all module-level singletons. */
+export function resetCacheState(): void {
+  cache = null
+  lastInjectedAt.clear()
+  lastModifiedAt = null
+}


### PR DESCRIPTION
Fixes #148. Exports a `resetCacheState()` helper that clears all module-level singletons (`cache`, `lastInjectedAt`, `lastModifiedAt`). Intended for use in unit test setup/teardown.