### PR TITLE
ci(e2e): run against production build to fix timeout flakiness

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,10 +37,16 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'npm run dev',
+    // In CI, test against a PRODUCTION build (next build && next start) instead
+    // of the dev server. `next dev` compiles routes on-demand at first hit, so
+    // under a test run the first request to each route can take many seconds —
+    // the source of the 30s timeouts / "WebServer aborted" flakiness. A prod
+    // build is fully precompiled, so responses are fast and stable (and it's
+    // what real users hit). Locally, keep the dev server for fast iteration.
+    command: process.env.CI ? 'pnpm build && pnpm start' : 'npm run dev',
     url: 'http://localhost:3000',
-    reuseExistingServer: true,
-    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI,
+    timeout: (process.env.CI ? 300 : 120) * 1000,
     // Env vars (NEXT_PUBLIC_SUPABASE_URL, TEST_USER_EMAIL, etc.) are read from
     // .env.test — load it before running: `dotenv -e .env.test -- npx playwright test`
     // In CI the env vars are injected via GitHub Actions secrets.


### PR DESCRIPTION
E2E was failing (22/25) mostly with 30s timeouts + `WebServer aborted` because CI ran Playwright against `next dev`, which compiles routes on-demand — slow first hits under a test run.

Switch CI to a **production build** (`next build && next start`): fully precompiled, fast + stable responses (and what real users hit). Dev server kept locally for iteration.

This PR's own e2e run is the test of whether it clears the flaky timeouts. Remaining failures after this = genuine selector/behavior issues to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)