### PR TITLE
polish(toast): redesign card styling + placement above history controls

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -495,3 +495,21 @@ body {
 .lucide[stroke-width='2'] {
   stroke-width: 1.5;
 }
+
+/* Undo toast placement: a cohesive card that floats ABOVE the sidebar dock
+   (history controls) rather than covering them, aligned to the sidebar's left
+   edge. Sonner 1.x only takes a single offset, so pin left+bottom here.
+   Desktop clears the dock (~156px); mobile sits above the tab bar + omnibar. */
+[data-sonner-toaster][data-y-position='bottom'][data-x-position='left'] {
+  left: 12px !important;
+  right: 12px !important;
+  bottom: 120px !important;
+}
+@media (min-width: 768px) {
+  [data-sonner-toaster][data-y-position='bottom'][data-x-position='left'] {
+    left: 20px !important;
+    right: auto !important;
+    bottom: 168px !important;
+    width: 356px !important;
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -509,7 +509,9 @@ body {
   [data-sonner-toaster][data-y-position='bottom'][data-x-position='left'] {
     left: 20px !important;
     right: auto !important;
-    bottom: 168px !important;
+    /* --toast-bottom is measured from the live dock (sidebar-dock.tsx); the
+       fallback covers the moment before it's set. */
+    bottom: var(--toast-bottom, 156px) !important;
     width: 356px !important;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -85,10 +85,10 @@ export default function RootLayout({
           <SupabaseProvider>
             {children}
           </SupabaseProvider>
-          {/* Bottom-left so the undo toast rises from the same corner as the
-              sidebar history controls; offset lifts it clear of the dock.
-              Single-value offset in sonner 1.x — tune if it sits too high/low. */}
-          <Toaster position="bottom-left" offset={96} closeButton />
+          {/* Bottom-left, above the sidebar history controls. Exact placement
+              (clear of the dock on desktop, above the tab bar on mobile) is a
+              globals.css override — sonner 1.x only takes a single offset. */}
+          <Toaster position="bottom-left" closeButton />
         </ThemeProvider>
         <Analytics />
       </body>

--- a/components/sidebar/sidebar-dock.tsx
+++ b/components/sidebar/sidebar-dock.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { ChatPanel } from '@/components/sidebar/chat-panel';
 import { UserCard } from '@/components/sidebar/user-card';
 import { Omnibar } from '@/components/sidebar/omnibar';
@@ -16,9 +17,34 @@ import { cn } from '@/lib/utils';
  */
 export function SidebarDock() {
   const chatExpanded = useSidebarStore((s) => s.chatExpanded);
+  const dockRef = useRef<HTMLDivElement>(null);
+
+  // Publish the dock's top edge (distance from the viewport bottom) as
+  // --toast-bottom so the undo toast can anchor just above it — exact instead
+  // of an estimate, and it follows the dock when chat expands/collapses.
+  useEffect(() => {
+    const el = dockRef.current;
+    if (!el) return;
+    const update = () => {
+      const top = el.getBoundingClientRect().top;
+      document.documentElement.style.setProperty(
+        '--toast-bottom',
+        `${Math.max(16, Math.round(window.innerHeight - top + 8))}px`
+      );
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    window.addEventListener('resize', update);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener('resize', update);
+    };
+  }, []);
 
   return (
     <div
+      ref={dockRef}
       data-tour="right-sidebar"
       className={cn(
         'flex min-h-0 flex-col rounded-[10px] bg-surface-3 px-[10px] pt-[18px] pb-[14px]',

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -3,6 +3,12 @@
 import { useTheme } from 'next-themes'
 import { Toaster as Sonner, ToasterProps } from 'sonner'
 
+/**
+ * Toaster restyled to the redesign: a soft-shadowed surface-2 card with a lime
+ * action button and chrome (Inter) type — cohesive with the sidebar dock /
+ * history popover it floats above. Position + placement (above the history
+ * controls) is set where it's mounted + a globals.css override.
+ */
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = 'system' } = useTheme()
 
@@ -17,6 +23,18 @@ const Toaster = ({ ...props }: ToasterProps) => {
           '--normal-border': 'var(--border)',
         } as React.CSSProperties
       }
+      toastOptions={{
+        classNames: {
+          toast:
+            'group !gap-3 !rounded-[12px] !border !border-border !bg-popover !px-4 !py-3.5 !shadow-[var(--shadow-soft-lg)]',
+          title: '!text-sm !font-medium !text-foreground',
+          description: '!text-xs !text-muted-foreground',
+          actionButton:
+            '!h-7 !rounded-[8px] !bg-primary !px-3 !text-xs !font-medium !text-primary-foreground hover:!bg-primary/90',
+          closeButton:
+            '!border-border !bg-surface-3 !text-muted-foreground hover:!text-foreground',
+        },
+      }}
       {...props}
     />
   )


### PR DESCRIPTION
Toast (undo notification) pass:
- **Restyle** to match the redesign — surface-2 card, 12px radius, soft-shadow-lg, Inter title, lime Undo button. Cohesive with the sidebar dock / history popover.
- **Reposition** above the history controls (not covering them) — globals.css override pins it clear of the dock on desktop and above the tab bar + omnibar on mobile. (Desktop bottom offset 168px estimates the dock height — easy to tune.)

Trigger any delete/complete/schedule to see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)