### PR TITLE
polish(mobile): header cleanup — user menu left, drop logo + add button

### DIFF
--- a/components/mobile/mobile-header.tsx
+++ b/components/mobile/mobile-header.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { format, isToday } from 'date-fns';
-import { Calendar, Plus, Rows3, List, Clock, Check, ChevronDown } from 'lucide-react';
+import { Calendar, Rows3, List, Clock, Check, ChevronDown } from 'lucide-react';
 import { UserProfileDropdown } from '@/components/planner/user-profile-dropdown';
 import { Button } from '@/components/ui/button';
 import { Calendar as CalendarComponent } from '@/components/ui/calendar';
@@ -15,10 +15,8 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { usePlannerStore } from '@/lib/planner-store';
 import { useViewStore, type ViewLayout } from '@/lib/view-store';
-import { cn } from '@/lib/utils';
 
 interface MobileHeaderProps {
-  onAddClick: () => void;
   onOpenSettings: () => void;
 }
 
@@ -29,7 +27,13 @@ const LAYOUTS: { value: ViewLayout; label: string; icon: typeof Rows3 }[] = [
   { value: 'schedule', label: 'Schedule', icon: Clock },
 ];
 
-export function MobileHeader({ onAddClick, onOpenSettings }: MobileHeaderProps) {
+/**
+ * Mobile header: user menu + date on the left, layout picker on the right.
+ * No logo (the user menu takes that slot) and no add button (the always-present
+ * omnibar strip handles capture). pt-safe lives on the outer element so the
+ * content row keeps symmetric vertical padding (stays centered) under the notch.
+ */
+export function MobileHeader({ onOpenSettings }: MobileHeaderProps) {
   const { selectedDate, setSelectedDate } = usePlannerStore();
   const { layout, setLayout } = useViewStore();
   const [mounted, setMounted] = useState(false);
@@ -41,55 +45,47 @@ export function MobileHeader({ onAddClick, onOpenSettings }: MobileHeaderProps) 
   const LayoutIcon = currentLayout.icon;
 
   return (
-    <header className="flex items-center justify-between border-b border-border bg-card px-4 py-3 pt-safe">
-      <div className="flex items-center gap-3">
-        <svg
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.75"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className="flex-shrink-0 text-foreground"
-          aria-label="Anchor"
-        >
-          <circle cx="12" cy="5" r="2" />
-          <line x1="12" y1="7" x2="12" y2="22" />
-          <path d="M5 12H2a10 10 0 0 0 20 0h-3" />
-        </svg>
+    <header className="border-b border-border bg-card pt-safe">
+      <div className="flex items-center justify-between px-3 py-2.5">
+        <div className="flex items-center gap-1">
+          <UserProfileDropdown onOpenSettings={onOpenSettings} />
+          <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                variant="ghost"
+                className="h-9 gap-1.5 px-2 text-sm font-medium text-foreground hover:bg-secondary"
+              >
+                <Calendar className="h-4 w-4 text-muted-foreground" />
+                {mounted ? (isToday(selectedDate) ? 'Today' : format(selectedDate, 'EEE, MMM d')) : <span className="w-16" />}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-auto p-0" align="start">
+              <CalendarComponent
+                mode="single"
+                selected={selectedDate}
+                onSelect={(date) => {
+                  if (date) setSelectedDate(date);
+                  setCalendarOpen(false);
+                }}
+                initialFocus
+              />
+            </PopoverContent>
+          </Popover>
+        </div>
 
-        <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
-          <PopoverTrigger asChild>
-            <Button variant="ghost" className="h-8 px-2 text-sm font-medium text-foreground hover:bg-secondary">
-              <Calendar className="mr-1.5 h-4 w-4 text-muted-foreground" />
-              {mounted ? (isToday(selectedDate) ? 'Today' : format(selectedDate, 'EEE, MMM d')) : <span className="w-16" />}
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent className="w-auto p-0" align="start">
-            <CalendarComponent
-              mode="single"
-              selected={selectedDate}
-              onSelect={(date) => {
-                if (date) setSelectedDate(date);
-                setCalendarOpen(false);
-              }}
-              initialFocus
-            />
-          </PopoverContent>
-        </Popover>
-      </div>
-
-      <div className="flex items-center gap-1">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="ghost" className="h-8 gap-1.5 px-2 text-sm font-medium text-foreground hover:bg-secondary" aria-label="Layout">
-              <LayoutIcon className="h-4 w-4" />
+            <Button
+              variant="ghost"
+              className="h-9 gap-1.5 px-2.5 text-sm font-medium text-foreground hover:bg-secondary"
+              aria-label="Layout"
+            >
+              <LayoutIcon className="h-4 w-4 text-muted-foreground" />
+              {currentLayout.label}
               <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="min-w-[140px]">
+          <DropdownMenuContent align="end" className="min-w-[150px]">
             {LAYOUTS.map((l) => {
               const Icon = l.icon;
               return (
@@ -102,17 +98,6 @@ export function MobileHeader({ onAddClick, onOpenSettings }: MobileHeaderProps) 
             })}
           </DropdownMenuContent>
         </DropdownMenu>
-
-        <UserProfileDropdown onOpenSettings={onOpenSettings} />
-
-        <Button
-          size="sm"
-          onClick={onAddClick}
-          className="h-8 w-8 bg-primary p-0 text-primary-foreground hover:bg-primary/90"
-          aria-label="Add"
-        >
-          <Plus className="h-4 w-4" />
-        </Button>
       </div>
     </header>
   );

--- a/components/shell/mobile-shell.tsx
+++ b/components/shell/mobile-shell.tsx
@@ -11,7 +11,7 @@ import { ScheduleSheet } from '@/components/mobile/schedule-sheet';
 import { Braindump } from '@/components/sidebar/braindump';
 import { Omnibar } from '@/components/sidebar/omnibar';
 import { useMobileNavStore, MOBILE_TAB_ORDER } from '@/lib/mobile-nav-store';
-import { openAddDialog, useUIStore } from '@/lib/ui-store';
+import { useUIStore } from '@/lib/ui-store';
 
 /**
  * Mobile layout: slim header + (Today-only) day strip, the active tab's
@@ -42,10 +42,7 @@ export function MobileShell() {
 
   return (
     <div className="flex h-[100dvh] flex-col bg-background md:hidden">
-      <MobileHeader
-        onAddClick={() => openAddDialog('task')}
-        onOpenSettings={() => openDialog({ type: 'settings' })}
-      />
+      <MobileHeader onOpenSettings={() => openDialog({ type: 'settings' })} />
 
       {activeTab === 'today' && <MiniWeekNav />}
 


### PR DESCRIPTION
Mobile header spacing/premium pass:
- **User menu moves left** (replaces the anchor logo); date next to it. Layout picker on the right, now with its label.
- **Remove the top add button** — the always-present omnibar strip covers capture.
- **Fix vertical centering** — `pt-safe` was overriding the row's top padding (0 on most phones) while the bottom padding stayed, pushing content up. Moved `pt-safe` to the outer element so the content row keeps symmetric vertical padding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Simplified the mobile header by removing the add-action button.
  * Reorganized header controls for clearer access to the profile, date picker, and layout selector.
  * Updated layout selector styling and menu sizing.
  * Removed the mobile header logo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->