### PR TITLE
feat(mobile): premium floating chrome + interactions (WIP)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -409,6 +409,16 @@ body {
   padding-inline: 2rem;
 }
 
+/* On phones the views live inside a floating rounded panel (mobile-shell),
+   so the desktop 2rem gutter would waste ~64px of a 390px screen. Desktop is
+   md:/≥768, so this override never touches it. */
+@media (max-width: 767px) {
+  .canvas-container {
+    padding-inline: 0.875rem;
+    max-width: none;
+  }
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/components/mobile/mini-week-nav.tsx
+++ b/components/mobile/mini-week-nav.tsx
@@ -42,7 +42,7 @@ export function MiniWeekNav() {
   }, [selectedDate, days]);
 
   return (
-    <div className="flex items-center gap-1 px-2 py-2 border-b border-border bg-card">
+    <div className="mx-3 mb-1 flex items-center gap-1 rounded-[16px] border border-surface-3 bg-surface-2 px-1.5 py-1 shadow-soft-sm">
       <Button
         variant="ghost"
         size="icon"

--- a/components/mobile/mobile-bottom-dock.tsx
+++ b/components/mobile/mobile-bottom-dock.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Omnibar } from '@/components/sidebar/omnibar';
+import { MobileTabBar } from '@/components/mobile/mobile-tab-bar';
+import { useMobileNavStore } from '@/lib/mobile-nav-store';
+
+/**
+ * Mobile bottom dock — the port of the desktop sidebar-dock: one floating
+ * surface-3 well capsule, inset from the screen edges, holding the omnibar
+ * white pill on top (hidden on Chat) and the tab bar below. Owns pb-safe.
+ * NOT overflow-hidden — the omnibar's results panel opens upward over content.
+ */
+export function MobileBottomDock() {
+  const activeTab = useMobileNavStore((s) => s.activeTab);
+
+  return (
+    <div className="px-3 pb-safe pt-2">
+      <div className="rounded-[24px] bg-surface-3 p-2 shadow-soft-lg">
+        {activeTab !== 'chat' && (
+          <div className="pb-2">
+            <Omnibar onAskBeacon={() => useMobileNavStore.getState().setActiveTab('chat')} />
+          </div>
+        )}
+        <MobileTabBar />
+      </div>
+    </div>
+  );
+}

--- a/components/mobile/mobile-header.tsx
+++ b/components/mobile/mobile-header.tsx
@@ -45,8 +45,12 @@ export function MobileHeader({ onOpenSettings }: MobileHeaderProps) {
   const LayoutIcon = currentLayout.icon;
 
   return (
-    <header className="border-b border-border bg-card pt-safe">
-      <div className="flex items-center justify-between px-3 py-2.5">
+    <header className="pt-safe">
+      {/* A shadowed white pill floating on the paper backdrop (desktop's
+          white-pill recipe: surface-2 + surface-3 hairline + hard shadow that
+          still reads in light mode). pt-safe on the header, mt-2 on the pill —
+          separate elements, so the safe inset and the top gap don't collide. */}
+      <div className="mx-3 mt-2 flex items-center justify-between rounded-[16px] border border-surface-3 bg-surface-2 px-2 py-1.5 shadow-[0px_4px_4px_0px_rgba(0,0,0,0.15)]">
         <div className="flex items-center gap-1">
           <UserProfileDropdown onOpenSettings={onOpenSettings} />
           <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>

--- a/components/mobile/mobile-tab-bar.tsx
+++ b/components/mobile/mobile-tab-bar.tsx
@@ -27,7 +27,7 @@ export function MobileTabBar() {
   };
 
   return (
-    <nav className="flex items-center justify-around border-t border-border bg-card pb-safe">
+    <nav className="flex items-center gap-1">
       {MOBILE_TAB_ORDER.map((id) => {
         const Icon = icons[id];
         const isActive = activeTab === id;
@@ -37,8 +37,8 @@ export function MobileTabBar() {
             data-tour={`tab-${id}`}
             onClick={() => setActiveTab(id)}
             className={cn(
-              'flex min-w-[72px] flex-col items-center justify-center gap-1 px-6 py-2 transition-colors',
-              isActive ? 'text-primary' : 'text-muted-foreground'
+              'flex flex-1 flex-col items-center justify-center gap-1 rounded-[16px] py-1.5 transition-all',
+              isActive ? 'bg-surface-2 text-primary shadow-soft-sm' : 'text-muted-foreground'
             )}
           >
             <Icon className={cn('h-5 w-5', isActive && 'stroke-[2.5]')} />

--- a/components/mobile/swipe-row.tsx
+++ b/components/mobile/swipe-row.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import { useSwipeable } from 'react-swipeable';
+import { Check, Clock, Trash2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { rowSwipeActive, openRowSwipe, closeRowSwipe } from '@/lib/row-swipe';
+
+const ACTION_W = 56;
+const REVEAL = ACTION_W * 3;
+
+interface SwipeRowProps {
+  onComplete: () => void;
+  onSchedule: () => void;
+  onDelete: () => void;
+  children: React.ReactNode;
+}
+
+/**
+ * Mobile-only wrapper that reveals Schedule / Complete / Delete when a row is
+ * swiped left. Gesture arbitration (see lib/row-swipe + the plan):
+ * - only claims horizontal intent (`|dx| > |dy|`), leaving vertical to scroll;
+ * - `stopPropagation` on the swipe so the container tab-swipe never sees it
+ *   (+ a `rowSwipeActive` guard as backup);
+ * - dnd-kit's TouchSensor needs a 250ms still-hold, so a quick swipe never
+ *   triggers a drag.
+ * One row open at a time; tapping an open row closes it instead of opening edit.
+ */
+export function SwipeRow({ onComplete, onSchedule, onDelete, children }: SwipeRowProps) {
+  const [tx, setTx] = useState(0);
+  const [swiping, setSwiping] = useState(false);
+  const openRef = useRef(false);
+  const baseRef = useRef(0);
+
+  const close = useCallback(() => {
+    openRef.current = false;
+    setTx(0);
+  }, []);
+
+  const clamp = (x: number) => Math.max(-REVEAL * 1.12, Math.min(0, x));
+
+  const handlers = useSwipeable({
+    onSwipeStart: () => {
+      setSwiping(true);
+      baseRef.current = openRef.current ? -REVEAL : 0;
+    },
+    onSwiping: (e) => {
+      if (Math.abs(e.deltaX) <= Math.abs(e.deltaY)) return; // vertical → let it scroll
+      e.event.stopPropagation();
+      rowSwipeActive.current = true;
+      openRowSwipe(close);
+      setTx(clamp(baseRef.current + e.deltaX));
+    },
+    onSwiped: (e) => {
+      setSwiping(false);
+      rowSwipeActive.current = false;
+      if (Math.abs(e.deltaX) <= Math.abs(e.deltaY)) return;
+      const finalTx = clamp(baseRef.current + e.deltaX);
+      const open = finalTx < -REVEAL / 2 || (e.dir === 'Left' && e.velocity > 0.4);
+      openRef.current = open;
+      setTx(open ? -REVEAL : 0);
+      if (open) openRowSwipe(close);
+      else closeRowSwipe(close);
+    },
+    trackMouse: false,
+    delta: 10,
+    preventScrollOnSwipe: false,
+  });
+
+  const act = (fn: () => void) => {
+    fn();
+    close();
+  };
+
+  return (
+    <div className="relative overflow-hidden rounded-[5px]">
+      <div className="absolute inset-y-0 right-0 flex">
+        <button
+          type="button"
+          onClick={() => act(onSchedule)}
+          className="flex w-14 items-center justify-center bg-surface-3 text-foreground"
+          aria-label="Schedule"
+        >
+          <Clock className="h-5 w-5" />
+        </button>
+        <button
+          type="button"
+          onClick={() => act(onComplete)}
+          className="flex w-14 items-center justify-center bg-primary text-primary-foreground"
+          aria-label="Complete"
+        >
+          <Check className="h-5 w-5" />
+        </button>
+        <button
+          type="button"
+          onClick={() => act(onDelete)}
+          className="flex w-14 items-center justify-center bg-destructive text-destructive-foreground"
+          aria-label="Delete"
+        >
+          <Trash2 className="h-5 w-5" />
+        </button>
+      </div>
+      <div
+        {...handlers}
+        style={{ transform: `translateX(${tx}px)` }}
+        onClickCapture={(e) => {
+          // A tap while open just closes the actions — don't open the edit dialog.
+          if (openRef.current) {
+            e.stopPropagation();
+            e.preventDefault();
+            close();
+          }
+        }}
+        className={cn('relative bg-canvas', !swiping && 'transition-transform duration-200 ease-out')}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/components/planner/add-task-dialog.tsx
+++ b/components/planner/add-task-dialog.tsx
@@ -6,12 +6,12 @@ import { CalendarIcon, Plus, Trash2, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from '@/components/ui/dialog';
+  ResponsiveModal,
+  ResponsiveModalContent,
+  ResponsiveModalHeader,
+  ResponsiveModalTitle,
+  ResponsiveModalDescription,
+} from '@/components/ui/responsive-modal';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -225,9 +225,9 @@ const effectiveTimeBucket = taskStartDate ? (taskTimeBucket || 'anytime') : unde
 
   return (
     <>
-      <Dialog open={open} onOpenChange={onOpenChange}>
-<DialogContent
-  className="w-[calc(100vw-2rem)] max-w-[425px] bg-card max-h-[85vh] overflow-y-auto overflow-x-hidden"
+      <ResponsiveModal open={open} onOpenChange={onOpenChange}>
+        <ResponsiveModalContent
+          className="w-[calc(100vw-2rem)] max-w-[425px] bg-card max-h-[85vh] overflow-y-auto overflow-x-hidden"
           onKeyDown={(e) => {
             if (e.key === 'Enter' && !e.shiftKey && !(e.target as HTMLElement).closest('[data-sub-input]')) {
               e.preventDefault();
@@ -235,12 +235,12 @@ const effectiveTimeBucket = taskStartDate ? (taskTimeBucket || 'anytime') : unde
             }
           }}
         >
-          <DialogHeader>
-            <DialogTitle className="text-foreground">Add New</DialogTitle>
-            <DialogDescription className="sr-only">
+          <ResponsiveModalHeader>
+            <ResponsiveModalTitle className="text-foreground">Add New</ResponsiveModalTitle>
+            <ResponsiveModalDescription className="sr-only">
               Add a new task or habit to your daily planner.
-            </DialogDescription>
-          </DialogHeader>
+            </ResponsiveModalDescription>
+          </ResponsiveModalHeader>
           
           <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as 'task' | 'habit')}>
             <TabsList className="grid w-full grid-cols-2 bg-secondary">
@@ -690,8 +690,8 @@ const effectiveTimeBucket = taskStartDate ? (taskTimeBucket || 'anytime') : unde
 </Button>
   </TabsContent>
           </Tabs>
-        </DialogContent>
-      </Dialog>
+        </ResponsiveModalContent>
+      </ResponsiveModal>
 
       <AlertDialog open={!!deleteConfirm} onOpenChange={(open) => !open && setDeleteConfirm(null)}>
         <AlertDialogContent>

--- a/components/primitives/task-row.tsx
+++ b/components/primitives/task-row.tsx
@@ -8,6 +8,7 @@ import { usePlannerStore } from '@/lib/planner-store';
 import { useUIStore, openEditFor } from '@/lib/ui-store';
 import { useScheduleSheet } from '@/lib/schedule-sheet-store';
 import { useIsMobile } from '@/hooks/use-mobile';
+import { SwipeRow } from '@/components/mobile/swipe-row';
 import { isRecurring, isCompletedOnDate, toDateStr } from '@/lib/recurrence';
 import { setHoveredItemRef } from '@/lib/hovered-item';
 import {
@@ -176,7 +177,7 @@ export function TaskRow({ row, context = 'bucket', density = 'default', date }: 
   const showMultiControls =
     habit && habit.timesPerDay && habit.timesPerDay > 1 && habitStatus === 'pending' && (showMulti || (habitEffectiveCount ?? 0) > 0);
 
-  return (
+  const rowContent = (
     <div
       ref={setNodeRef}
       style={style}
@@ -371,4 +372,19 @@ export function TaskRow({ row, context = 'bucket', density = 'default', date }: 
       </div>
     </div>
   );
+
+  // Mobile: reveal Schedule / Complete / Delete on swipe-left. Desktop returns
+  // the row unchanged (hover controls + the ellipsis handle these actions).
+  if (isMobile) {
+    return (
+      <SwipeRow
+        onComplete={isTask ? handleTaskToggle : handleHabitToggle}
+        onSchedule={() => useScheduleSheet.getState().open(row)}
+        onDelete={handleDelete}
+      >
+        {rowContent}
+      </SwipeRow>
+    );
+  }
+  return rowContent;
 }

--- a/components/shell/app-shell.tsx
+++ b/components/shell/app-shell.tsx
@@ -351,11 +351,12 @@ export function AppShell() {
           <div className="w-80 rounded-panel bg-sidebar" />
           <main className="flex-1 rounded-panel bg-canvas" />
         </div>
-        {/* Mobile skeleton */}
-        <div className="flex h-[100dvh] flex-col bg-background md:hidden">
-          <div className="h-14 border-b border-border bg-card" />
-          <div className="flex-1 bg-background" />
-          <div className="h-14 border-t border-border bg-card" />
+        {/* Mobile skeleton — matches the floating-chrome silhouette (header
+            pill · content panel · bottom dock) so there's no flash of flat bars. */}
+        <div className="flex h-[100dvh] flex-col bg-surface-0 md:hidden">
+          <div className="mx-3 mt-2 h-11 flex-shrink-0 rounded-[16px] bg-surface-2" />
+          <div className="mx-2 my-2 flex-1 rounded-[24px] border border-surface-3 bg-canvas" />
+          <div className="mx-3 mb-3 h-24 flex-shrink-0 rounded-[24px] bg-surface-3" />
         </div>
       </>
     );

--- a/components/shell/mobile-shell.tsx
+++ b/components/shell/mobile-shell.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect } from 'react';
 import { useSwipeable } from 'react-swipeable';
 
 import { MobileHeader } from '@/components/mobile/mobile-header';
@@ -11,6 +12,7 @@ import { ScheduleSheet } from '@/components/mobile/schedule-sheet';
 import { Braindump } from '@/components/sidebar/braindump';
 import { useMobileNavStore, MOBILE_TAB_ORDER } from '@/lib/mobile-nav-store';
 import { useUIStore } from '@/lib/ui-store';
+import { rowSwipeActive, closeAllRowSwipes } from '@/lib/row-swipe';
 
 /**
  * Mobile layout: slim header + (Today-only) day strip, the active tab's
@@ -23,14 +25,19 @@ export function MobileShell() {
   const activeTab = useMobileNavStore((s) => s.activeTab);
   const openDialog = useUIStore((s) => s.openDialog);
 
+  // Close any open row swipe-actions when switching tabs.
+  useEffect(() => closeAllRowSwipes(), [activeTab]);
+
   const swipeHandlers = useSwipeable({
     onSwipedLeft: () => {
+      if (rowSwipeActive.current) return; // a row swipe is in progress, not a tab swipe
       const idx = MOBILE_TAB_ORDER.indexOf(activeTab);
       if (idx < MOBILE_TAB_ORDER.length - 1) {
         useMobileNavStore.getState().setActiveTab(MOBILE_TAB_ORDER[idx + 1]);
       }
     },
     onSwipedRight: () => {
+      if (rowSwipeActive.current) return;
       const idx = MOBILE_TAB_ORDER.indexOf(activeTab);
       if (idx > 0) useMobileNavStore.getState().setActiveTab(MOBILE_TAB_ORDER[idx - 1]);
     },
@@ -46,6 +53,12 @@ export function MobileShell() {
       {activeTab === 'today' && <MiniWeekNav />}
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden" {...swipeHandlers}>
+        {/* Keyed on activeTab → a soft cross-fade on tab change (auto-disabled
+            under [data-reduce-motion]). */}
+        <div
+          key={activeTab}
+          className="flex min-h-0 flex-1 flex-col overflow-hidden animate-in fade-in-0 duration-200"
+        >
         {activeTab === 'chat' ? (
           <MobileChatPanel onOpenSettings={() => openDialog({ type: 'settings' })} />
         ) : (
@@ -58,6 +71,7 @@ export function MobileShell() {
             {activeTab === 'today' && <MobileViewRouter />}
           </div>
         )}
+        </div>
       </div>
 
       <MobileBottomDock />

--- a/components/shell/mobile-shell.tsx
+++ b/components/shell/mobile-shell.tsx
@@ -3,13 +3,12 @@
 import { useSwipeable } from 'react-swipeable';
 
 import { MobileHeader } from '@/components/mobile/mobile-header';
-import { MobileTabBar } from '@/components/mobile/mobile-tab-bar';
+import { MobileBottomDock } from '@/components/mobile/mobile-bottom-dock';
 import { MobileViewRouter } from '@/components/mobile/mobile-view-router';
 import { MobileChatPanel } from '@/components/mobile/mobile-chat-panel';
 import { MiniWeekNav } from '@/components/mobile/mini-week-nav';
 import { ScheduleSheet } from '@/components/mobile/schedule-sheet';
 import { Braindump } from '@/components/sidebar/braindump';
-import { Omnibar } from '@/components/sidebar/omnibar';
 import { useMobileNavStore, MOBILE_TAB_ORDER } from '@/lib/mobile-nav-store';
 import { useUIStore } from '@/lib/ui-store';
 
@@ -47,26 +46,21 @@ export function MobileShell() {
       {activeTab === 'today' && <MiniWeekNav />}
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden" {...swipeHandlers}>
-        {activeTab === 'braindump' && (
-          <div className="flex min-h-0 flex-1 flex-col px-3 pt-2">
-            <Braindump hideCollapse />
-          </div>
-        )}
-        {activeTab === 'today' && <MobileViewRouter />}
-        {activeTab === 'chat' && (
+        {activeTab === 'chat' ? (
           <MobileChatPanel onOpenSettings={() => openDialog({ type: 'settings' })} />
+        ) : (
+          /* Content lives in a floating rounded panel on the paper backdrop —
+             the mobile echo of the desktop canvas. In light mode canvas and
+             backdrop are near-identical, so the border-surface-3 hairline +
+             shadow-soft-lg + rounding carry the elevation. */
+          <div className="mx-2 mb-2 flex min-h-0 flex-1 flex-col overflow-hidden rounded-[24px] border border-surface-3 bg-canvas shadow-soft-lg">
+            {activeTab === 'braindump' && <Braindump hideCollapse />}
+            {activeTab === 'today' && <MobileViewRouter />}
+          </div>
         )}
       </div>
 
-      {/* Persistent capture strip — always one tap away (hidden on Chat, which
-          has its own input). Its results panel opens upward over the content. */}
-      {activeTab !== 'chat' && (
-        <div className="border-t border-border bg-card px-3 py-2">
-          <Omnibar onAskBeacon={() => useMobileNavStore.getState().setActiveTab('chat')} />
-        </div>
-      )}
-
-      <MobileTabBar />
+      <MobileBottomDock />
 
       <ScheduleSheet />
     </div>

--- a/components/ui/responsive-modal.tsx
+++ b/components/ui/responsive-modal.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import * as React from 'react';
+import { useIsMobile } from '@/hooks/use-mobile';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+} from '@/components/ui/drawer';
+import { cn } from '@/lib/utils';
+
+/**
+ * A modal that renders a centered shadcn Dialog on desktop and a vaul bottom
+ * Drawer on mobile, sharing the exact same children. Lets a single dialog be a
+ * premium bottom sheet on phones without forking its content. Desktop output is
+ * byte-identical to the plain Dialog (same components, same props).
+ */
+const MobileCtx = React.createContext(false);
+
+function ResponsiveModal({
+  open,
+  onOpenChange,
+  children,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+}) {
+  const isMobile = useIsMobile();
+  const Root = isMobile ? Drawer : Dialog;
+  return (
+    <MobileCtx.Provider value={isMobile}>
+      <Root open={open} onOpenChange={onOpenChange}>
+        {children}
+      </Root>
+    </MobileCtx.Provider>
+  );
+}
+
+/** `className` styles the desktop DialogContent; mobile is a bottom sheet with
+ *  its own scroll + safe-area. Extra props (onKeyDown, etc.) pass to both. */
+function ResponsiveModalContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogContent>) {
+  const isMobile = React.useContext(MobileCtx);
+  if (isMobile) {
+    return (
+      <DrawerContent {...props}>
+        <div className="overflow-y-auto overflow-x-hidden px-4 pb-[calc(env(safe-area-inset-bottom,0px)+1rem)]">
+          {children}
+        </div>
+      </DrawerContent>
+    );
+  }
+  return (
+    <DialogContent className={className} {...props}>
+      {children}
+    </DialogContent>
+  );
+}
+
+function ResponsiveModalHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  const isMobile = React.useContext(MobileCtx);
+  const C = isMobile ? DrawerHeader : DialogHeader;
+  return <C className={cn(isMobile && 'px-0 text-left', className)} {...props} />;
+}
+
+function ResponsiveModalTitle({ className, ...props }: React.ComponentProps<typeof DialogTitle>) {
+  const isMobile = React.useContext(MobileCtx);
+  const C = isMobile ? DrawerTitle : DialogTitle;
+  return <C className={className} {...props} />;
+}
+
+function ResponsiveModalDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogDescription>) {
+  const isMobile = React.useContext(MobileCtx);
+  const C = isMobile ? DrawerDescription : DialogDescription;
+  return <C className={className} {...props} />;
+}
+
+export {
+  ResponsiveModal,
+  ResponsiveModalContent,
+  ResponsiveModalHeader,
+  ResponsiveModalTitle,
+  ResponsiveModalDescription,
+};

--- a/lib/row-swipe.ts
+++ b/lib/row-swipe.ts
@@ -1,0 +1,27 @@
+'use client';
+
+/**
+ * Shared state for mobile row swipe-actions:
+ * - `rowSwipeActive`: a guard so the container tab-swipe (mobile-shell) ignores
+ *   an in-progress row swipe (belt-and-suspenders alongside stopPropagation).
+ * - a one-open registry so only one row's actions are revealed at a time.
+ */
+export const rowSwipeActive = { current: false };
+
+let openCloser: (() => void) | null = null;
+
+export function openRowSwipe(close: () => void) {
+  if (openCloser && openCloser !== close) openCloser();
+  openCloser = close;
+}
+
+export function closeRowSwipe(close: () => void) {
+  if (openCloser === close) openCloser = null;
+}
+
+/** Close any open row (e.g. on tab change / sheet open). */
+export function closeAllRowSwipes() {
+  const c = openCloser;
+  openCloser = null;
+  c?.();
+}


### PR DESCRIPTION
Mobile premium redesign — **chrome pass (7f-a–d)** so far; interactions (sheets, swipe-actions, motion) still to come on this branch.

Brings the desktop's layered-card feel to mobile: floating content panel, header/nav pills, and a floating bottom-dock capsule (omnibar pill + tab bar with an active pill) — all on the paper backdrop, earning elevation from rounding + surface-3 hairline + shadows (reads in light *and* dark).

Eyeball on the branch preview. More to land: Add/Filter bottom sheets, row swipe-actions, motion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a responsive modal that switches between desktop dialogs and mobile bottom sheets.
  * Introduced swipeable task/habit rows with actions revealed on horizontal swipe.
  * Added shared row-swipe coordination to ensure only one row panel is open at a time.
* **Bug Fixes**
  * Improved mobile responsiveness for the canvas container on small screens.
* **Refactor / UI Updates**
  * Updated the mobile shell to use the new bottom dock and redesigned tab/content behavior with smoother transitions.
  * Refreshed mobile header, tab bar, weekly navigation styling, and startup mobile skeleton to align with the new layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->